### PR TITLE
Add gulp-useref to html task. Add usemin blocks. Add bundle task. Update...

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -140,8 +140,7 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
     html: this.indexFile,
     fileType: 'js',
     optimizedPath: 'scripts/main.js',
-    sourceFileList: ['scripts/main.js'],
-    searchPath: 'app'
+    sourceFileList: ['scripts/main.js']
   });
 };
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,16 +7,15 @@
     "gulp-load-plugins": "~0.3.0",
     "gulp-util": "~2.2.9",
     "gulp-autoprefixer": "~0.0.6",
-    "gulp-csso": "~0.2.3",
     "gulp-jshint": "~1.4.0",
     "gulp-imagemin": "~0.1.4",
     "gulp-clean": "~0.2.4",
-    "gulp-uglify": "~0.2.0",
-    "gulp-concat": "~2.1.7",
     "gulp-cache": "~0.1.1",
     "gulp-ruby-sass": "~0.3.0",
     "gulp-size": "~0.1.2",
-    "gulp-connect": "~0.3.0"
+    "gulp-connect": "~0.3.0",
+    "gulp-useref": "~0.1.2",
+    "gulp-bundle": "~0.2.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -14,8 +14,7 @@ gulp.task('styles', function () {
           loadPath: ['app/bower_components']
         }))
         .pipe($.autoprefixer('last 1 version'))
-        .pipe($.csso())
-        .pipe(gulp.dest('dist/styles'))
+        .pipe(gulp.dest('app/styles'))
         .pipe($.size());
 });
 
@@ -24,15 +23,13 @@ gulp.task('scripts', function () {
     return gulp.src('app/scripts/**/*.js')
         .pipe($.jshint('.jshintrc'))
         .pipe($.jshint.reporter('default'))
-        .pipe($.concat('main.js'))
-        .pipe($.uglify())
-        .pipe(gulp.dest('dist/scripts'))
         .pipe($.size());
 });
 
 // HTML
 gulp.task('html', function () {
     return gulp.src('app/*.html')
+      .pipe($.useref())
       .pipe(gulp.dest('dist'))
       .pipe($.size());
 });
@@ -54,8 +51,11 @@ gulp.task('clean', function () {
     return gulp.src(['dist/styles', 'dist/scripts', 'dist/images'], {read: false}).pipe($.clean());
 });
 
+// Bundle
+gulp.task('bundle', ['styles', 'scripts'], $.bundle('./app/*.html'));
+
 // Build
-gulp.task('build', ['html', 'styles', 'scripts', 'images']);
+gulp.task('build', ['html', 'bundle', 'images']);
 
 // Default task
 gulp.task('default', ['clean'], function () {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,12 +9,19 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-
-        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% } %>
-
+        <% if (includeBootstrap && !includeCompass) { %>
+        <!-- build:css styles/vendor.css -->
+        <!-- bower:css -->
+        <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
+        <!-- endbower -->
+        <!-- endbuild -->
+        <% } %>
+        <!-- build:css styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
-        <% if (includeModernizr) { %>
+        <!-- endbuild --><% if (includeModernizr) { %>
+        <!-- build:js scripts/vendor/modernizr.js -->
         <script src="bower_components/modernizr/modernizr.js"></script>
+        <!-- endbuild -->
         <% } %>
     </head>
     <body>
@@ -74,7 +81,11 @@
         </div>
         <% } %>
 
+        <!-- build:js scripts/vendor.js -->
+        <!-- bower:js -->
         <script src="bower_components/jquery/jquery.js"></script>
+        <!-- endbower -->
+        <!-- endbuild -->
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>


### PR DESCRIPTION
... styles, scripts tasks.

This adds support for usemin by using `gulp-useref` to parse the usemin tags and replace them with the combined files in the html and by using `gulp-bundle` in a separate task to handle the actual bundling of the files.
