### PR TITLE
add Compass to Ruby Sass options

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -11,6 +11,7 @@ gulp.task('styles', function () {
     return gulp.src('app/styles/main.scss')
         .pipe($.rubySass({
           style: 'expanded',
+          compass: true,
           loadPath: ['app/bower_components']
         }))
         .pipe($.autoprefixer('last 1 version'))


### PR DESCRIPTION
Though the generator config prompt mentions "Sass with Compass", Compass is not being currently included in the Sass task.
