### PR TITLE
add wiredep support.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,8 @@
     "gulp-size": "~0.1.2",
     "gulp-connect": "~1.0.0",
     "gulp-useref": "~0.1.2",
-    "gulp-bundle": "~0.2.0"
+    "gulp-bundle": "~0.2.0",
+    "wiredep": "~1.1.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -2,6 +2,7 @@
 // Generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
 
 var gulp = require('gulp');
+var wiredep = require('wiredep').stream;
 
 // Load plugins
 var $ = require('gulp-load-plugins')();
@@ -70,6 +71,23 @@ gulp.task('connect', $.connect.server({
     livereload: true
 }));
 
+// Inject Bower components
+gulp.task('wiredep', function () {
+    gulp.src('app/styles/*.scss')
+        .pipe(wiredep({
+            directory: 'app/bower_components',
+            ignorePath: 'app/bower_components/'
+        }))
+        .pipe(gulp.dest('app/styles'));
+
+    gulp.src('app/*.html')
+        .pipe(wiredep({
+            directory: 'app/bower_components',
+            ignorePath: 'app/'
+        }))
+        .pipe(gulp.dest('app'));
+});
+
 // Watch
 gulp.task('watch', ['connect'], function () {
     // Watch for changes in `app` folder
@@ -92,4 +110,7 @@ gulp.task('watch', ['connect'], function () {
 
     // Watch image files
     gulp.watch('app/images/**/*', ['images']);
+
+    // Watch bower files
+    gulp.watch('app/bower_components/*', ['wiredep']);
 });

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,6 +1,8 @@
 <% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vender/assets/fonts/";
 
-@import 'bootstrap-sass/vendor/assets/stylesheets/bootstrap';
+// bower:scss
+@import "bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss";
+// endbower
 
 .browsehappy {
     margin: 0.2em 0;
@@ -83,7 +85,7 @@ body {
     .header {
         margin-bottom: 30px;
     }
-    
+
     /* Remove the bottom border on the jumbotron for visual effect */
     .jumbotron {
         border-bottom: 0;


### PR DESCRIPTION
I'm a noob with gulp and all this fancy stuff.

I released wiredep 1.1.0 with stream (?) support: https://github.com/stephenplusplus/wiredep/commit/37b9850088a9ecbb86e2cefb6232ac4e8707469a

I tested this, and it works. So, please, smart people test now :)

It sets up a watch on `bower_components`, so that any time you install a package, it will run wiredep. Works nicely!

It also uses the name `wiredep`, as opposed to `bowerInstall`. So, it's `gulp wiredep`.
