### PR TITLE
fixed root path value types.

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -64,7 +64,7 @@ gulp.task('default', ['clean'], function () {
 
 // Connect
 gulp.task('connect', $.connect.server({
-    root: __dirname + '/app',
+    root: ['app'],
     port: 9000,
     livereload: true
 }));


### PR DESCRIPTION
Ref: https://github.com/AveVlad/gulp-connect#optionsroot

Default type is array not string.
