### PR TITLE
Supporting a new gulp-useref workflow.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,9 @@
     "gulp-size": "~0.1.2",
     "gulp-connect": "~1.0.0",
     "gulp-useref": "~0.1.2",
-    "gulp-bundle": "~0.2.0",
+    "gulp-uglify": "~0.2.1",
+    "gulp-minify-css": "~0.3.0",
+    "gulp-filter": "~0.3.0",
     "wiredep": "~1.1.0"
   },
   "engines": {


### PR DESCRIPTION
I have a [proposed change](https://github.com/jonkemp/gulp-useref/pull/3) over on [gulp-useref](https://github.com/jonkemp/gulp-useref) that makes the workflow a bit more flexible and more gulp-like. For reference, the discussion actually [started](https://github.com/jonkemp/gulp-bundle/pull/5) over on [gulp-bundle](https://github.com/jonkemp/gulp-bundle).

The change here make the Yeoman gulp workflow a little easier to understand (in my opinion) and a bit more gulp-like.

This will have to wait for the pull request to go through on gulp-useref and for a new version of that plugin to be released, but I wanted to at least allow opportunity for discussion both here and on the useref plugin in case anyone sees opportunities for improvement.
