### PR TITLE
Remove bundle task.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,16 +7,18 @@
     "gulp-load-plugins": "~0.3.0",
     "gulp-util": "~2.2.9",
     "gulp-autoprefixer": "~0.0.6",
+    "gulp-csso": "~0.2.6",
     "gulp-jshint": "~1.4.0",
     "gulp-imagemin": "~0.1.4",
     "gulp-clean": "~0.2.4",
+    "gulp-uglify": "~0.2.1",
     "gulp-cache": "~0.1.1",<% if (includeSass) { %>
     "gulp-ruby-sass": "~0.3.0",<% } %>
     "gulp-size": "~0.1.2",
     "gulp-connect": "~1.0.0",
-    "gulp-useref": "~0.1.2",
-    "gulp-bundle": "~0.2.0",
-    "wiredep": "~1.3.0"
+    "gulp-useref": "~0.2.1",
+    "wiredep": "~1.3.0",
+    "gulp-filter": "~0.3.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -29,8 +29,19 @@ gulp.task('scripts', function () {
 });
 
 // HTML
-gulp.task('html', function () {
+gulp.task('html', [<% if (includeSass) { %>'styles', <% } %>'scripts'], function () {
+    var jsFilter = $.filter('**/*.js');
+    var cssFilter = $.filter('**/*.css');
+
     return gulp.src('app/*.html')
+      .pipe($.useref.assets())
+      .pipe(jsFilter)
+      .pipe($.uglify())
+      .pipe(jsFilter.restore())
+      .pipe(cssFilter)
+      .pipe($.csso())
+      .pipe(cssFilter.restore())
+      .pipe($.useref.restore())
       .pipe($.useref())
       .pipe(gulp.dest('dist'))
       .pipe($.size());
@@ -53,11 +64,8 @@ gulp.task('clean', function () {
     return gulp.src([<% if (includeSass) { %>'dist/styles', <% } %>'dist/scripts', 'dist/images'], {read: false}).pipe($.clean());
 });
 
-// Bundle
-gulp.task('bundle', [<% if (includeSass) { %>'styles', <% } %>'scripts'], $.bundle('./app/*.html'));
-
 // Build
-gulp.task('build', ['html', 'bundle', 'images']);
+gulp.task('build', ['html', 'images']);
 
 // Default task
 gulp.task('default', ['clean'], function () {


### PR DESCRIPTION
gulp-bundle is deprecated. gulp-useref now has the ability to concatenate assets inside build blocks and pass them to the stream. Minification of assets is now handled in the gulpfile instead of gulp-bundle. gulp-filter is required to handle filtering the stream for asset minification.
