### PR TITLE
use shorthand for bootstrap-sass and versioning with tilde

### DIFF
--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "private": true,
   "dependencies": {<% if (includeBootstrap) { if (includeSass) { %>
-    "bootstrap-sass": "git://github.com/twbs/bootstrap-sass.git#v3.1.0",<% } else { %>
+    "bootstrap-sass": "twbs/bootstrap-sass#~3.1.0",<% } else { %>
     "bootstrap": "~3.0.3",<% }} if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>
     "jquery": "~1.11.0"


### PR DESCRIPTION
Minor change. As of today, bower would install `bootstrap-sass` with `v3.1.1`.
