### PR TITLE
fix missing styles when using sass

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('connect', $.connect.server({
 }));
 
 // Open
-gulp.task('serve', function() {
+gulp.task('serve', ['connect'<% if (includeSass) { %>, 'styles'<% } %>], function() {
   open("http://localhost:9000");
 });
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,13 +9,13 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-        <% if (includeBootstrap) { %>
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
+        <% if (includeBootstrap && !includeSass) { %>
         <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
+        <% } %>
         <!-- endbower -->
         <!-- endbuild -->
-        <% } %>
         <!-- build:css styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>


### PR DESCRIPTION
For #15, 'watch' does not depend on 'styles' in any way; 'serve' does not depend on 'connect' may result in opening page before server is up.

Also included a minor fix to not include `bootstrap.min.css` when using sass.
