### PR TITLE
Formatting + Introduce wiredep

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,8 +11,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
         <!-- build:css styles/vendor.css -->
-        <!-- bower:css --><% if (includeBootstrap && !includeSass) { %>
-        <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% } %>
+        <!-- bower:css -->
         <!-- endbower -->
         <!-- endbuild -->
 
@@ -88,7 +87,6 @@
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->
-        <script src="bower_components/jquery/dist/jquery.js"></script>
         <!-- endbower -->
         <!-- endbuild -->
     </body>

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,7 +1,6 @@
 <% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
-@import "bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss";
 // endbower
 
 .browsehappy {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "yeoman-generator": "~0.16.0",
     "cheerio": "~0.13.0",
-    "chalk": "~0.4.0"
+    "chalk": "~0.4.0",
+    "wiredep": "^1.4.3"
   },
   "peerDependencies": {
     "yo": ">=1.0.0",


### PR DESCRIPTION
Two commits here:

1) format the scaffolded `index.html` more prettily. Random spacing issues are now resolved!

2) use `wiredep` to inject dependencies during scaffolding, instead of manually templating them wrapped in `<% if %>`s in the html / scss.

It works! And it looks good :+1: 
