### PR TITLE
Add `fonts` task to generator

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -19,7 +19,9 @@
     "gulp-useref": "~0.2.1",
     "wiredep": "~1.3.0",
     "gulp-filter": "~0.3.1",
-    "open": "~0.0.4"
+    "open": "~0.0.4",
+    "gulp-flatten": "~0.0.2",
+    "gulp-bower-files": "~0.2.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -68,13 +68,26 @@ gulp.task('images', function () {
         .pipe($.size());
 });
 
+gulp.task('fonts', function () {
+    return $.bowerFiles()
+        .pipe($.filter([
+            '**/*.eot',
+            '**/*.svg',
+            '**/*.ttf',
+            '**/*.woff'
+        ]))
+        .pipe($.flatten())
+        .pipe(gulp.dest('dist/fonts'))
+        .pipe($.size());
+});
+
 // Clean
 gulp.task('clean', function () {
-    return gulp.src(['dist/styles', 'dist/scripts', 'dist/images'], { read: false }).pipe($.clean());
+    return gulp.src(['dist/styles', 'dist/scripts', 'dist/images', 'dist/fonts'], { read: false }).pipe($.clean());
 });
 
 // Build
-gulp.task('build', ['html', 'images']);
+gulp.task('build', ['html', 'images', 'fonts']);
 
 // Default task
 gulp.task('default', ['clean'], function () {

--- a/test/gulp_file.js
+++ b/test/gulp_file.js
@@ -63,6 +63,10 @@ describe('Gulp Webapp generator: tasks', function () {
     assertTaskExists(this.webapp, "images", [], done);
   });
 
+  it('should contain fonts task', function (done) {
+    assertTaskExists(this.webapp, "fonts", [], done);
+  });
+
   it('should contain clean task', function (done) {
     assertTaskExists(this.webapp, "clean", [], done);
   });


### PR DESCRIPTION
In cases where a Bower package defines font assets (identified as `.eot`, `.svg`, `.ttf`, and `.woff` files) these will be copied to `dist/fonts` upon building the app.

Discussed in #60
