### PR TITLE
Minor compass support fix

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -14,7 +14,8 @@ gulp.task('styles', function () {
     return gulp.src('app/styles/main.scss')
         .pipe($.rubySass({
           style: 'expanded',
-          loadPath: ['app/bower_components']
+          loadPath: ['app/bower_components'],
+          compass: true
         }))
         .pipe($.autoprefixer('last 1 version'))
         .pipe(gulp.dest('app/styles'))


### PR DESCRIPTION
Hello there,

According to gulp-ruby-sass (https://github.com/sindresorhus/gulp-ruby-sass) plugin, you need the compass option to be true if you want compass support.

best regards,
John
