### PR TITLE
watch *.css file in both cases to prevent reload to early

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -129,9 +129,8 @@ gulp.task('wiredep', function () {
 gulp.task('watch', ['connect', 'serve'], function () {
     // Watch for changes in `app` folder
     gulp.watch([
-        'app/*.html',<% if (includeSass) { %>
-        'app/styles/**/*.scss',<% } else { %>
-        'app/styles/**/*.css',<% } %>
+        'app/*.html',
+        'app/styles/**/*.css',
         'app/scripts/**/*.js',
         'app/images/**/*'
     ], function (event) {


### PR DESCRIPTION
if sass is used, a reload is triggered when you edit the sass source before the new css file is ready.
With this change a reload is send once the new css file is avaiable. 
