### PR TITLE
Fix wiredep ignorePaths

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -120,14 +120,13 @@ gulp.task('wiredep', function () {
     gulp.src('app/styles/*.<% if (includeSass) { %>scss<% } else { %>css<% } %>')
         .pipe(wiredep({
             directory: 'app/bower_components',
-            ignorePath: 'app/bower_components/'
+            ignorePath: '../bower_components/'
         }))
         .pipe(gulp.dest('app/styles'));
 
     gulp.src('app/*.html')
         .pipe(wiredep({
-            directory: 'app/bower_components',
-            ignorePath: 'app/'
+            directory: 'app/bower_components'
         }))
         .pipe(gulp.dest('app'));
 });


### PR DESCRIPTION
wiredep made the paths relative to the injected file.  taptapship/wiredep@9f22e28b3b44901d3a09f35848d8dabb7070e077
