### PR TITLE
Exclude bootstrap.js file from wiredep

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -128,7 +128,8 @@ gulp.task('wiredep', function () {
     gulp.src('app/*.html')
         .pipe(wiredep({
             directory: 'app/bower_components',
-            ignorePath: 'app/'
+            ignorePath: 'app/',
+            exclude: ['app/bower_components/bootstrap-sass/vendor/assets/javascripts/bootstrap.js']
         }))
         .pipe(gulp.dest('app'));
 });


### PR DESCRIPTION
Bootstrap's JS components are already included, and that's what `bootstrap.js` is made of. Right?
