### PR TITLE
Fix Bootstrap imports

### DIFF
--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -2,8 +2,8 @@
   "name": "<%= _.slugify(appname) %>",
   "private": true,
   "dependencies": {<% if (includeBootstrap) { if (includeSass) { %>
-    "bootstrap-sass-official": "~3.1.1",<% } else { %>
-    "bootstrap": "~3.1.1",<% }} if (includeModernizr) { %>
+    "bootstrap-sass-official": "3.1.0",<% } else { %>
+    "bootstrap": "3.1.0",<% }} if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>
     "jquery": "~1.11.0"
   },


### PR DESCRIPTION
[According to node-semver](https://github.com/isaacs/node-semver#ranges) `3.1.1` yields to `3.1.1+1`. (I didn't even know about `+` version types before, while we're at it :confused:) That version causes problems because it has that new `bower.json` setup which I don't currently know how to deal with here. It imports a [`bootstrap-mincer`](https://github.com/twbs/bootstrap-sass/blob/7f6ffed53c30f285034ddba0a9695171b75e0713/vendor/assets/stylesheets/_bootstrap-mincer.scss) file which I don't see how it should work outside of Rails, with all the `asset_path` helpers and stuff. I posted a [comment](https://github.com/twbs/bootstrap-sass/pull/586#issuecomment-40971561) about this, waiting for an answer...

That's why I downgraded (Sass) Bootstrap to 3.1.0 until we figure this out. This should finally fix #85, #86, #83.
