### PR TITLE
Build local fonts also

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -152,6 +152,7 @@ AppGenerator.prototype.app = function () {
   this.mkdir('app/scripts');
   this.mkdir('app/styles');
   this.mkdir('app/images');
+  this.mkdir('app/fonts');
   this.write('app/index.html', this.indexFile);
   this.write('app/scripts/main.js', 'console.log(\'\\\'Allo \\\'Allo!\');');
 };

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,6 +23,7 @@
     "gulp-useref": "^0.3.1",
     "jshint-stylish": "^0.1.5",
     "opn": "^0.1.1",
+    "streamqueue": "^0.0.6",
     "wiredep": "^1.4.3"
   },
   "engines": {

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -54,7 +54,11 @@ gulp.task('images', function () {
 });
 
 gulp.task('fonts', function () {
-    return $.bowerFiles()
+    var streamqueue = require('streamqueue');
+    return streamqueue({objectMode: true},
+        $.bowerFiles(),
+        gulp.src('app/fonts/**/*')
+    )
         .pipe($.filter('**/*.{eot,svg,ttf,woff}'))
         .pipe($.flatten())
         .pipe(gulp.dest('dist/fonts'))


### PR DESCRIPTION
An empty `app/fonts` directory will be created on `yo gulp-webapp` because now people can put their webfonts there and they will be compiled to `dist/fonts`, along with fonts from Bower packages, i.e. the ones specified in `main` in `bower.json`. They can be referenced from stylesheets with `../fonts/webfont.ext`.
