### PR TITLE
Fix jshint-stylish reporter

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('styles', function () {<% if (includeSass) { %>
 gulp.task('scripts', function () {
     return gulp.src('app/scripts/**/*.js')
         .pipe($.jshint())
-        .pipe($.jshint.reporter($.jshintStylish))
+        .pipe($.jshint.reporter(require('jshint-stylish')))
         .pipe($.size());
 });
 


### PR DESCRIPTION
$.jshintStylish was undefined.

The `gulp-load-plugins` module only loads plugins matching glob `gulp-*` by default.
