### PR TITLE
don't ignore dotfiles in extras task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -62,7 +62,7 @@ gulp.task('fonts', function () {
 });
 
 gulp.task('extras', function () {
-    return gulp.src(['app/*.*', '!app/*.html'])
+    return gulp.src(['app/*.*', '!app/*.html'], { dot: true })
         .pipe(gulp.dest('dist'));
 });
 


### PR DESCRIPTION
this allows dotfiles such as `.htaccess` to be copied to dist using the extras tasks. 
Part of #92 , also discussed here https://github.com/yeoman/generator-gulp-webapp/commit/018bdbdf44f8a0413c6bcf2ea1d9e7099b34378b
