### PR TITLE
Transfer useref search path to the gulpfile

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,7 @@
     "gulp-ruby-sass": "^0.4.3",<% } %>
     "gulp-size": "^0.3.0",
     "gulp-uglify": "^0.2.1",
-    "gulp-useref": "^0.3.1",
+    "gulp-useref": "^0.4.2",
     "jshint-stylish": "^0.1.5",
     "opn": "^0.1.1",
     "wiredep": "^1.4.3"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('html', ['styles', 'scripts'], function () {
     var cssFilter = $.filter('**/*.css');
 
     return gulp.src('app/*.html')
-        .pipe($.useref.assets())
+        .pipe($.useref.assets({searchPath: '{.tmp/app}'}))
         .pipe(jsFilter)
         .pipe($.uglify())
         .pipe(jsFilter.restore())

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
         <!-- endbower -->
         <!-- endbuild -->
 
-        <!-- build:css({.tmp,app}) styles/main.css -->
+        <!-- build:css styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
         <% if (includeModernizr) { %>


### PR DESCRIPTION
I tend to forget to add that `{.tmp/app}` if I somehow delete it or decide to use another preprocessor like CoffeeScript, which also compiles to `.tmp`. This way it only needs to be included once.

I'm not sure if this affects performance in any way, I don't know how to test that.
