### PR TITLE
Bootstrap-sass requires a minimum precision of 10

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -9,7 +9,8 @@ var $ = require('gulp-load-plugins')();
 gulp.task('styles', function () {<% if (includeSass) { %>
     return gulp.src('app/styles/main.scss')
         .pipe($.rubySass({
-            style: 'expanded'
+            style: 'expanded',
+            precision: 10
         }))<% } else { %>
     return gulp.src('app/styles/main.css')<% } %>
         .pipe($.autoprefixer('last 1 version'))


### PR DESCRIPTION
 (see https://github.com/twbs/bootstrap-sass#number-precision)
