### PR TITLE
Use gulp-size after build, not in serve/watch

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -72,11 +72,10 @@ gulp.task('clean', function () {
 });
 
 gulp.task('build', ['jshint', 'html', 'images', 'fonts', 'extras'], function () {
-    return gulp.src('dist/**/*')
-        .pipe($.size({
-            showFiles: true,
-            gzip: true
-        }));
+    return gulp.src('dist/**/*').pipe($.size({
+        showFiles: true,
+        gzip: true
+    }));
 });
 
 gulp.task('default', ['clean'], function () {


### PR DESCRIPTION
I suggest doing gulp-size only after build. It doesn't make sense to report the individual filesizes of unminified, unconcatenated sources after every save. It encouarages a bad way to think about performance.

A single report after build is more readable and more interesting:

![screenshot 2014-05-11 22 11 46](https://cloud.githubusercontent.com/assets/250617/2939601/e9711b5c-d950-11e3-8361-c9642a1a434e.png)

I know it doesn't feel very gulpy to do a `gulp.src` to read just-created files off disk (as I've done in the build task)... I suppose we could alternatively include `$.size()` in the pipelines of all the `app=>dist` tasks (`html`, `images`, `fonts`, and `extras`). But I think it's better to do it as a final job at the end, because (a) you get the report in one chunk of consecutive lines, and (b) you get a useful total.
