### PR TITLE
update gitignore after moving bower_components

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 .tmp
 .sass-cache
-app/bower_components
+bower_components
 test/bower_components


### PR DESCRIPTION
as of https://github.com/yeoman/generator-gulp-webapp/commit/fdb1f7d493304e65a95a0dda63b05d2ffcd2a1b6 `bower_components` lives in the root, and should ignored
