### PR TITLE
fix for fonts not building with gulp

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -58,7 +58,11 @@ gulp.task('images', function () {
 gulp.task('fonts', function () {
     var streamqueue = require('streamqueue');
     return streamqueue({objectMode: true},
-        $.bowerFiles(),
+        $.bowerFiles({
+        paths: {
+            bowerDirectory: 'app/bower_components'
+            }
+        }),
         gulp.src('app/fonts/**/*')
     )
         .pipe($.filter('**/*.{eot,svg,ttf,woff}'))


### PR DESCRIPTION
The font build was failing, looking for ./bower_components.
