### PR TITLE
Add "clearcache" task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -76,6 +76,10 @@ gulp.task('clean', function () {
     return gulp.src(['.tmp', 'dist'], { read: false }).pipe($.clean());
 });
 
+gulp.task('clearcache', function () {
+    return $.cache.clearAll();
+});
+
 gulp.task('build', ['jshint', 'html', 'images', 'fonts', 'extras']);
 
 gulp.task('default', ['clean'], function () {


### PR DESCRIPTION
Sometimes images get heavily cached after running through **imagemin**.
I found out that the only way to fix this was to use the `cache.clearAll()`function.

I've added a task called **clearcache** for that.
You use it by explicitly calling it.

```
gulp clearcache
```
