### PR TITLE
Don't let watch task crash on Sass syntax errors

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -19,7 +19,8 @@
   "gulp-livereload": "^2.0.0",
   "gulp-load-plugins": "^0.5.0",<% if (includeSass) { if (includeBootstrap) { %>
   "gulp-replace": "^0.3.0",<% } %>
-  "gulp-ruby-sass": "^0.5.0",<% } %>
+  "gulp-ruby-sass": "^0.5.0",
+  "gulp-plumber": "^0.6.3",<% } %>
   "gulp-size": "^0.4.0",
   "gulp-uglify": "^0.3.0",
   "gulp-useref": "^0.4.2",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -6,6 +6,7 @@ var rimraf = require('rimraf');
 
 gulp.task('styles', function () {<% if (includeSass) { %>
   return gulp.src('app/styles/main.scss')
+    .pipe($.plumber())
     .pipe($.rubySass({
       style: 'expanded',
       precision: 10


### PR DESCRIPTION
Fixes #154

Suggestion: while the issue at orchestrator/orchestrator#46 is still pending it would probably make sense to monkey patch this with [gulp-plumber](https://github.com/floatdrop/gulp-plumber/).
