### PR TITLE
Require middleware Connect 3.0 style

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -28,6 +28,8 @@
     "jshint-stylish": "^0.2.0",<% if (includeBootstrap && includeSass) { %>
     "lazypipe": "^0.2.1",<% } %>
     "opn": "^0.1.1",
+    "serve-index": "^1.1.4",
+    "serve-static": "^1.2.3",
     "streamqueue": "^0.1.1",
     "wiredep": "^1.4.3"
   }

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -66,15 +66,19 @@ gulp.task('extras', function () {
 gulp.task('clean', require('del').bind(null, ['.tmp', 'dist']));
 
 gulp.task('connect', function () {
-  var connect = require('connect');
+  var connect = require('connect'),
+      livereload = require('connect-livereload'),
+      serveStatic = require('serve-static'),
+      serveIndex = require('serve-index');
+
   var app = connect()
-    .use(require('connect-livereload')({port: 35729}))
-    .use(connect.static('app'))
-    .use(connect.static('.tmp'))
+    .use(livereload({port: 35729}))
+    .use(serveStatic('app'))
+    .use(serveStatic('.tmp'))
     // paths to bower_components should be relative to the current file
     // e.g. in app/index.html you should use ../bower_components
-    .use('/bower_components', connect.static('bower_components'))
-    .use(connect.directory('app'));
+    .use('/bower_components', serveStatic('bower_components'))
+    .use(serveIndex('app'));
 
   require('http').createServer(app)
     .listen(9000)


### PR DESCRIPTION
As of Connect 3.0 all middleware-ish functionality have been separated into require'able modules: https://github.com/senchalabs/connect#middleware.

Fixes a breaking change introduced by yeoman/generator-gulp-webapp@b1aadb4.
