### PR TITLE
Clarify build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Please see our [gulpfile.js](app/templates/gulpfile.js) for up to date informati
 
 - Install: `npm install -g generator-gulp-webapp`
 - Run: `yo gulp-webapp`
-- Run `gulp` for building and `gulp serve` for preview
+- Run: `gulp` for building and `gulp serve` for preview
+- Run: `gulp build` to build a deployable "dist" directory
 
 
 #### Third-Party Dependencies


### PR DESCRIPTION
As a newbie, it was hard to understand how to use the ".tmp" folder created by `gulp watch`. 
By clarifying how to `gulp build` and specifying the target directory, I believe we make the generator much more accessible by all. 

Also, consistency correction with ":" after "Run"
