### PR TITLE
Bump gulp-cache version for rename bugfix

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -10,7 +10,7 @@
     "gulp": "^3.6.0",
     "gulp-autoprefixer": "^0.0.7",
     "gulp-bower-files": "^0.2.1",
-    "gulp-cache": "^0.1.1",
+    "gulp-cache": "^0.2.0",
     "gulp-csso": "^0.2.6",
     "gulp-filter": "^0.5.0",
     "gulp-flatten": "^0.0.2",


### PR DESCRIPTION
Fixes #151.

This is an issue with `gulp-cache` itself. See jgable/gulp-cache#27 and the pull request at jgable/gulp-cache#28.

Bump the `gulp-cache` version in `package.json` to `^0.2.0` to include this bugfix.
