### PR TITLE
add "gulp" to npm scripts

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "gulp": "gulp"
+  },
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
https://www.npmjs.org/doc/misc/npm-scripts.html#path

This ensures that any gulp commands are run using the version installed locally to the project's `node_modules/.bin` directory and not the global version.

Helpful when running builds on a shared build server.
