### PR TITLE
Bump gulp-useref to 0.6.0 and use the new syntax

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,7 +23,7 @@
     "gulp-plumber": "^0.6.3",<% } %>
     "gulp-size": "^0.4.0",
     "gulp-uglify": "^0.3.0",
-    "gulp-useref": "^0.4.2",
+    "gulp-useref": "^0.6.0",
     "jshint-stylish": "^0.2.0",<% if (includeBootstrap && includeSass) { %>
     "lazypipe": "^0.2.1",<% } %>
     "main-bower-files": "^1.0.1",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -27,13 +27,14 @@ gulp.task('html', ['styles'], function () {<% if (includeBootstrap && includeSas
   var cssChannel = lazypipe()
     .pipe($.csso)
     .pipe($.replace, 'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap','fonts');<% } %>
+  var assets = $.useref.assets({searchPath: '{.tmp,app}'});
 
   return gulp.src('app/*.html')
-    .pipe($.useref.assets({searchPath: '{.tmp,app}'}))
+    .pipe(assets)
     .pipe($.if('*.js', $.uglify()))<% if (includeBootstrap && includeSass) { %>
     .pipe($.if('*.css', cssChannel()))<% } else { %>
     .pipe($.if('*.css', $.csso()))<% } %>
-    .pipe($.useref.restore())
+    .pipe(assets.restore())
     .pipe($.useref())
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
This is more of an enhancement. Version 0.6.0 simplfies the syntax and _allows for multiple instances of useref_, jonkemp/gulp-useref@668ae87.
