### PR TITLE
Add bower injection even when not using Bootstrap

### DIFF
--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -89,7 +89,10 @@ body {
   .jumbotron {
     border-bottom: 0;
   }
-}<% } else { %>body {
+}<% } else { %>// bower:scss
+// endbower
+
+body {
   background: #fafafa;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   color: #333;


### PR DESCRIPTION
When not choosing bootstrap, Bower injections in the `main.scss` were not possible.
