### PR TITLE
Fixing duplicate inclusion of bootstrap via wiredep

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -196,7 +196,7 @@ AppGenerator.prototype.install = function () {
       wiredep({
         bowerJson: bowerJson,
         directory: 'bower_components',
-        exclude: ['bootstrap-sass', 'bootstrap'],
+        exclude: ['bootstrap-sass', 'bootstrap.js'],
         src: 'app/index.html'
       });
 


### PR DESCRIPTION
Both bootstrap.js and /bootstrap/js/*.js are being included in the generated application template. This seems to originate from the wiredep step, I have added an ignore that solves this issue.
