### PR TITLE
Add 'gulp help' task using 'gulp-task-listing'

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,6 +23,7 @@
     "gulp-ruby-sass": "^0.5.0",
     "gulp-plumber": "^0.6.3",<% } %>
     "gulp-size": "^0.4.0",
+    "gulp-task-listing": "^0.3.0",
     "gulp-uglify": "^0.3.0",
     "gulp-useref": "^0.6.0",
     "jshint-stylish": "^0.2.0",<% if (includeBootstrap && includeSass) { %>

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -3,6 +3,11 @@
 var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();
 
+var taskListing = require('gulp-task-listing');
+
+// Add a task to render the output
+gulp.task('help', taskListing);
+
 gulp.task('styles', function () {<% if (includeSass) { %>
   return gulp.src('app/styles/main.scss')
     .pipe($.plumber())


### PR DESCRIPTION
This adds a `help` task to `gulpfile.js`. It is the default implementation using [gulp-task-listing](https://www.npmjs.org/package/gulp-task-listing).

The `help` task lists the tasks supported by this project. It doesn't display any additional information. Still, it can be quite useful in getting acquainted with generator-gulp-webapp and comparing it's options to generator-webapp.
