### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,5 @@
   "newcap": true,
   "noarg": true,
   "undef": true,
-  "strict": false,
-  "trailing": true,
-  "smarttabs": true
+  "strict": false
 }

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -15,7 +15,5 @@
   "undef": true,
   "unused": true,
   "strict": true,
-  "trailing": true,
-  "smarttabs": true,
   "jquery": true
 }


### PR DESCRIPTION
`trailing` and `smarttabs` are removed since jshint v2.5
