### PR TITLE
Add language indicator to <html>

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html<% if (includeModernizr) { %> class="no-js"<% } %>>
+<html<% if (includeModernizr) { %> class="no-js"<% } %> lang="">
   <head>
     <meta charset="utf-8">
     <meta name="description" content="">


### PR DESCRIPTION
I think there should be a lang attribute added to the `<html>` tag.
- It's good SEO
- Language tagging is recommended by the W3C Web Accessibility Guidelines
- `:lang()` CSS selector can be used.

Relevant to:
- https://github.com/google/web-starter-kit/commit/9d0eac7775758fab7020342a312a974df98bf349
- https://github.com/h5bp/html5-boilerplate/issues/1542
- https://github.com/yeoman/generator-mobile/pull/62
