### PR TITLE
Add `Disallow:` to robots.txt

### DIFF
--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -1,3 +1,4 @@
 # robotstxt.org/
 
 User-agent: * 
+Disallow:


### PR DESCRIPTION
According to the [robots.txt standard](http://www.robotstxt.org/orig.html):

> The record starts with one or more User-agent lines, followed by one or more Disallow lines, as detailed below.

See the [discussion about this in h5bp too](https://github.com/h5bp/html5-boilerplate/issues/1487)
