### PR TITLE
Simplify Bootstrap font path to avoid replacing

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -26,8 +26,7 @@
     "gulp-size": "^1.1.0",
     "gulp-uglify": "^1.0.1",
     "gulp-useref": "^1.0.2",
-    "jshint-stylish": "^1.0.0",<% if (includeBootstrap && includeSass) { %>
-    "lazypipe": "^0.2.1",<% } %>
+    "jshint-stylish": "^1.0.0",
     "main-bower-files": "^2.1.0",
     "opn": "^1.0.0",
     "serve-index": "^1.1.4",

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: '../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/';
+<% if (includeBootstrap) { %>$icon-font-path: '../fonts/';
 
 // bower:scss
 // endbower


### PR DESCRIPTION
With this change Bootstrap font path is the same both in development and in production, so no need for replacing the path, yay :smiley: 

Thanks to @austinpray for the idea.
