### PR TITLE
no need place 'connect' before 'watch' task.

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -85,7 +85,7 @@ gulp.task('connect', ['styles', 'fonts'], function () {
     });
 });
 
-gulp.task('serve', ['connect', 'watch'], function () {
+gulp.task('serve', ['watch'], function () {
   require('opn')('http://localhost:9000');
 });
 


### PR DESCRIPTION
no need place 'connect' before 'watch' task, because the watch task itself will require the connect task run firstly.
