### PR TITLE
Remove `minimal-ui` viewport property

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= appname %></title>
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 


### PR DESCRIPTION
The `minimal-ui` viewport property was introduced in iOS 7.1, but is no longer supported in iOS 8.

Ref https://developer.apple.com/library/prerelease/ios/releasenotes/General/RN-iOSSDK-8.0/#//apple_ref/doc/uid/TP40014223-CH1-SW83
