### PR TITLE
Revert to Ruby Sass and add sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,13 @@ Please see our [gulpfile.js](app/templates/gulpfile.js) for up to date informati
 
 * CSS Autoprefixing
 * Built-in preview server with BrowserSync
-* Automagically compile Sass with [libsass](http://libsass.org)
+* Automagically compile Sass
+* Map compiled CSS to source stylesheets with source maps
 * Automagically lint your scripts
 * Awesome image optimization
 * Automagically wire-up dependencies installed with [Bower](http://bower.io)
 
 *For more information on what this generator can do for you, take a look at the [gulp plugins](app/templates/_package.json) used in our `package.json`.*
-
-
-## libsass
-
-Keep in mind that libsass is feature-wise not fully compatible with Ruby Sass. Check out [this](http://sass-compatibility.github.io) curated list of incompatibilities to find out which features are missing.
-
-If your favorite feature is missing and you really need Ruby Sass, you can always switch to [gulp-ruby-sass](https://github.com/sindresorhus/gulp-ruby-sass) and update the `styles` task in `gulpfile.js` accordingly.
 
 
 ## Getting Started

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,8 +18,9 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-html": "^0.1.6",
     "gulp-postcss": "^3.0.0",<% if (includeSass) { %>
-    "gulp-sass": "^1.2.4",<% } %>
+    "gulp-ruby-sass": "^1.0.0-alpha.3",<% } %>
     "gulp-size": "^1.1.0",
+    "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",
     "gulp-useref": "^1.0.2",
     "jshint-stylish": "^1.0.0",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -7,17 +7,18 @@ var browserSync = require('browser-sync');
 var reload = browserSync.reload;
 
 gulp.task('styles', function () {<% if (includeSass) { %>
-  return gulp.src('app/styles/main.scss')
-    .pipe($.sass({
-      outputStyle: 'nested', // libsass doesn't support expanded yet
-      precision: 10,
-      includePaths: ['.'],
-      onError: console.error.bind(console, 'Sass error:')
-    }))<% } else { %>
-  return gulp.src('app/styles/main.css')<% } %>
+  return $.rubySass('app/styles/main.scss', {
+    sourcemap: true,
+    style: 'expanded',
+    precision: 10,
+    loadPath: ['.']
+  })<% } else { %>
+  return gulp.src('app/styles/main.css')
+    .pipe($.sourcemaps.init())<% } %>
     .pipe($.postcss([
       require('autoprefixer-core')({browsers: ['last 1 version']})
     ]))
+    .pipe($.sourcemaps.write())
     .pipe(gulp.dest('.tmp/styles'));
 });
 


### PR DESCRIPTION
Sourcemaps will be generated without Sass as well, for PostCSS.

Fixes #256.
