### PR TITLE
Don't remove IDs from SVGs when optimizing

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -49,7 +49,10 @@ gulp.task('images', function () {
   return gulp.src('app/images/**/*')
     .pipe($.cache($.imagemin({
       progressive: true,
-      interlaced: true
+      interlaced: true,
+      // don't remove IDs from SVGs, they are often used
+      // as hooks for embedding and styling
+      svgoPlugins: [{cleanupIDs: false}]
     })))
     .pipe(gulp.dest('dist/images'));
 });


### PR DESCRIPTION
IDs are often used for styling and embedding SVGs (via `<use>`, Snap.svg etc.)
