### PR TITLE
Added asset revision.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,6 +17,8 @@
     "gulp-minify-html": "^1.0.0",
     "gulp-postcss": "^4.0.3",<% if (includeSass) { %>
     "gulp-sass": "^1.3.3",<% } %>
+    "gulp-rev-all": "^0.7.6",
+    "gulp-rev-napkin": "^0.1.0",
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^1.1.0",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -42,7 +42,6 @@ gulp.task('html', ['styles'], function () {
     .pipe($.if('*.css', $.csso()))
     .pipe(assets.restore())
     .pipe($.useref())
-    .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
     .pipe(gulp.dest('dist'));
 });
 
@@ -131,7 +130,12 @@ gulp.task('wiredep', function () {
 });
 
 gulp.task('build', ['jshint', 'html', 'images', 'fonts', 'extras'], function () {
-  return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
+  return gulp.src('dist/**/*', {base: 'dist'})
+    .pipe($.revAll({ignore: ['favicon.ico', 'apple-touch-icon.png', 'robots.txt', '.html']}))
+    .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
+    .pipe($.revNapkin())
+    .pipe(gulp.dest('dist'))
+    .pipe($.size({title: 'build', gzip: true}));
 });
 
 gulp.task('default', ['clean'], function () {


### PR DESCRIPTION
See the discussion at #255 this is the napkin-solution. 
I have made the least changes to the current setup of the gulp file.
- adds two new plugins: rev-all and rev-napkin
  - Rev-all takes care of adding revisions numbers to assets.
  - Rev-Napkin removes the (duplicate) un-revved files from the stream
- moved HTML minification to the build task, as it interferes with the revision management
- added default ignores for revisons: all html files, favicon, touch-icons and robots.txt
