### PR TITLE
Update gulp-postcss to 5.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
     "node": ">=0.12.0"
   },
   "devDependencies": {
-    "autoprefixer-core": "^5.1.7",
+    "autoprefixer-core": "^5.1.8",
     "browser-sync": "^2.2.1",
     "del": "^1.1.1",
     "gulp": "^3.8.11",
@@ -15,7 +15,7 @@
     "gulp-jshint": "^1.9.2",
     "gulp-load-plugins": "^0.8.1",
     "gulp-minify-html": "^1.0.0",
-    "gulp-postcss": "^4.0.3",<% if (includeSass) { %>
+    "gulp-postcss": "^5.0.0",<% if (includeSass) { %>
     "gulp-sass": "^1.3.3",<% } %>
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.0",


### PR DESCRIPTION
`gulp-postcss` 4.0 uses very old version of PostCSS and some of users [have a problems](https://github.com/postcss/postcss/issues/282#issuecomment-89789797)

/cc @silvenon 
