### PR TITLE
Added clearing of gulp-cache to clean task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -75,7 +75,10 @@ gulp.task('extras', function () {
   }).pipe(gulp.dest('dist'));
 });
 
-gulp.task('clean', require('del').bind(null, ['.tmp', 'dist']));
+gulp.task('clean', function(done){
+  require('del')(['.tmp', 'dist']);
+  return $.cache.clearAll(done);
+});
 
 gulp.task('serve', ['styles', 'fonts'], function () {
   browserSync({


### PR DESCRIPTION
I've changed some image's names and even after gulp clean I got old filenames in dist/ dir. Adding clearing of gulp-cache fixed issue.
