### PR TITLE
Use `https://` in the Google Analytics snippet

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -79,7 +79,7 @@
       (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
       function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
       e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-      e.src='//www.google-analytics.com/analytics.js';
+      e.src='https://www.google-analytics.com/analytics.js';
       r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
       ga('create','UA-XXXXX-X');ga('send','pageview');
     </script>


### PR DESCRIPTION
Same change in generator-webapp: https://github.com/yeoman/generator-webapp/commit/ab9cf491ca872bde7f7dfd7733cfe2f04132fcce

Ref h5bp/html5-boilerplate@eee759b
       https://developers.google.com/speed/libraries/?csw=1#libraries
       https://github.com/konklone/cdns-to-https#conclusion-cdns-should-redirect-to-https
