### PR TITLE
Update gulp-sass

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
     "gulp-load-plugins": "^0.8.1",
     "gulp-minify-html": "^1.0.0",
     "gulp-postcss": "^5.0.0",<% if (includeSass) { %>
-    "gulp-sass": "^1.3.3",<% } %>
+    "gulp-sass": "^2.0.0",<% } %>
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^1.1.0",


### PR DESCRIPTION
A new version of gulp-sass including node-sass v3.0.0 and libsass v3.2.0 has been released.
