### PR TITLE
Sass: Log errors nicely

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -12,9 +12,8 @@ gulp.task('styles', function () {<% if (includeSass) { %>
     .pipe($.sass({
       outputStyle: 'expanded',
       precision: 10,
-      includePaths: ['.'],
-      onError: console.error.bind(console, 'Sass error:')
-    }))<% } else { %>
+      includePaths: ['.']
+    }).on('error', $.sass.logError))<% } else { %>
   return gulp.src('app/styles/*.css')
     .pipe($.sourcemaps.init())<% } %>
     .pipe($.postcss([


### PR DESCRIPTION
According to the new `gulp-sass` version, we can now log errors nicely.
More information can be found here:
https://github.com/dlmanning/gulp-sass#basic-usage
