### PR TITLE
made jQuery optional

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -76,6 +76,14 @@ module.exports = generators.Base.extend({
         value: 'includeModernizr',
         checked: true
       }]
+    }, {
+      type: 'confirm',
+      name: 'includeJQuery',
+      message: 'Would you like to include jQuery?',
+      default: true,
+      when: function (answers) {
+        return answers.features.indexOf('includeBootstrap') === -1;
+      }
     }];
 
     this.prompt(prompts, function (answers) {
@@ -90,6 +98,7 @@ module.exports = generators.Base.extend({
       this.includeSass = hasFeature('includeSass');
       this.includeBootstrap = hasFeature('includeBootstrap');
       this.includeModernizr = hasFeature('includeModernizr');
+      this.includeJQuery = answers.includeJQuery;
 
       done();
     }.bind(this));
@@ -143,7 +152,8 @@ module.exports = generators.Base.extend({
           name: _s.slugify(this.appname),
           includeSass: this.includeSass,
           includeBootstrap: this.includeBootstrap,
-          includeModernizr: this.includeModernizr
+          includeModernizr: this.includeModernizr,
+          includeJQuery: this.includeJQuery
         }
       );
     },
@@ -218,6 +228,7 @@ module.exports = generators.Base.extend({
           includeSass: this.includeSass,
           includeBootstrap: this.includeBootstrap,
           includeModernizr: this.includeModernizr,
+          includeJQuery: this.includeJQuery,
           bsPath: bsPath,
           bsPlugins: [
             'affix',

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {<% if (includeBootstrap) { if (includeSass) { %>
     "bootstrap-sass": "~3.3.1"<% } else { %>
-    "bootstrap": "~3.3.1"<% }} else { %>
+    "bootstrap": "~3.3.1"<% }} else if (includeJQuery) { %>
     "jquery": "~2.1.1"<% } if (includeModernizr) { %>,
     "modernizr": "~2.8.1" <% } %>
   }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -70,7 +70,8 @@
       <ul>
         <li>HTML5 Boilerplate</li><% if (includeSass) { %>
         <li>Sass</li><% } %><% if (includeModernizr) { %>
-        <li>Modernizr</li><% } %>
+        <li>Modernizr</li><% } %><% if (includeJQuery) { %>
+        <li>jQuery</li><% } %>
       </ul>
     </div>
     <% } %>

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -16,7 +16,7 @@ describe('Bootstrap feature', function () {
         .on('end', done);
     });
 
-    it('shoud add the correct dependencies', function () {
+    it('should add the correct dependencies', function () {
       assert.fileContent('bower.json', '"bootstrap-sass"');
       assert.noFileContent('bower.json', '"jquery"');
     });

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -1,0 +1,40 @@
+'use strict';
+var path = require('path');
+var helpers = require('yeoman-generator').test;
+var assert = require('yeoman-assert');
+
+describe('jQuery feature', function () {
+  describe('on', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(__dirname, 'temp'))
+        .withOptions({'skip-install': true})
+        .withPrompts({
+          features: [],
+          includeJQuery: true
+        })
+        .on('end', done);
+    });
+
+    it('should add the correct dependencies', function () {
+      assert.fileContent('bower.json', '"jquery"');
+    });
+  });
+
+  describe('off', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(__dirname, 'temp'))
+        .withOptions({'skip-install': true})
+        .withPrompts({
+          features: [],
+          includeJQuery: false
+        })
+        .on('end', done);
+    });
+
+    it('should add the correct dependencies', function () {
+      assert.noFileContent('bower.json', '"jquery"');
+    });
+  });
+});


### PR DESCRIPTION
When Bootstrap is not selected, added a prompt to optionally disclude jQuery (well, include jQuery, default yes). I've started too many projects with `yo gulp-webapp && bower uninstall --save jquery && gulp wiredep`!
