### PR TITLE
Fix incorrect bootstrap script tags

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -88,7 +88,7 @@
 <% if (includeBootstrap) { -%>
     <!-- build:js scripts/plugins.js -->
 <% bsPlugins.forEach(function (plugin) { -%>
-    <script type="<%= bsPath + plugin %>.js"></script>
+    <script src="<%= bsPath + plugin %>.js"></script>
 <% }) -%>
     <!-- endbuild -->
 <% } -%>

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -22,7 +22,7 @@ describe('Bootstrap feature', function () {
     });
 
     it('should output the correct <script> paths', function () {
-      assert.fileContent('app/index.html', '/bootstrap-sass/assets/javascripts/bootstrap/');
+      assert.fileContent('app/index.html', /src=\"(.*?)\/bootstrap-sass\/assets\/javascripts\/bootstrap\//);
     });
 
     it('should contain the font icon path variable', function () {
@@ -47,7 +47,7 @@ describe('Bootstrap feature', function () {
     });
 
     it('should output the correct <script> paths', function () {
-      assert.fileContent('app/index.html', '/bootstrap/js/');
+      assert.fileContent('app/index.html', /src=\"(.*?)\/bootstrap\/js\//);
     });
   });
 });


### PR DESCRIPTION
Currently in the index.html file, the bootstrap script tags are mistakenly generated with the `type` attribute instead of `src`, like this (which prevents them from loading and actually working):

``` html
<script type="/bower_components/bootstrap-sass/assets/javascripts/bootstrap/affix.js"></script>
<script type="/bower_components/bootstrap-sass/assets/javascripts/bootstrap/alert.js"></script>
<script type="/bower_components/bootstrap-sass/assets/javascripts/bootstrap/dropdown.js"></script>
<script type="/bower_components/bootstrap-sass/assets/javascripts/bootstrap/tooltip.js"></script>
...
```

and so on.

This PR fixes this and updates the tests to make sure that the `src` attribute is used.
