### PR TITLE
Fixes lint:test and serve:test with the default files

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -35,13 +35,13 @@ function lint(files, options) {
   };
 }
 const testLintOptions = {
-  "env": {
-    "mocha": true
+  env: {
+    mocha: true
   },
-  "globals": {
-    "assert": false,
-    "expect": false,
-    "should": false
+  globals: {
+    assert: false,
+    expect: false,
+    should: false
   }
 };
 


### PR DESCRIPTION
I ran into problems running tests with a newly-generated app.  This PR fixes those issues.
- The `lint:test` task needs some options to pass the default mocha test file.
- The `serve:test` task needs a route to the bower components
- The `serve:test` task should open a browser like the other `serve` tasks.  
