### PR TITLE
Add bower.json overrides for bootstrap (#338)

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,9 +2,26 @@
   "name": "<%= name %>",
   "private": true,
   "dependencies": {<% if (includeBootstrap) { if (includeSass) { %>
-    "bootstrap-sass": "3.3.4"<% } else { %>
-    "bootstrap": "3.3.4"<% }} else if (includeJQuery) { %>
+    "bootstrap-sass": "~3.3.5"<% } else { %>
+    "bootstrap": "~3.3.5"<% }} else if (includeJQuery) { %>
     "jquery": "~2.1.1"<% } if (includeModernizr) { %>,
     "modernizr": "~2.8.1" <% } %>
-  }
+  }<% if (includeBootstrap) { %>,
+  "overrides": {<% if (includeSass) { %>
+    "bootstrap-sass": {
+      "main": [
+        "assets/stylesheets/_bootstrap.scss",
+        "assets/fonts/bootstrap/*",
+        "assets/javascripts/bootstrap.js"
+      ]
+    } <% } else { %>
+    "bootstrap": {
+      "main": [
+        "less/bootstrap.less",
+        "dist/css/bootstrap.css",
+        "dist/js/bootstrap.js",
+        "dist/fonts/*"
+      ]
+    } <% } %>
+  } <% } %>
 }

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -65,6 +65,16 @@ describe('Bootstrap feature', function () {
     it('should contain the font icon path variable', function () {
       assert.fileContent('app/styles/main.scss', '$icon-font-path');
     });
+
+    it('should correctly override bootstrap\'s bower.json', function() {
+      assert.fileContent('bower.json', '"overrides"');
+
+      assert.fileContent('bower.json', 'assets/stylesheets/_bootstrap.scss');
+
+      assert.fileContent('bower.json', 'assets/fonts/bootstrap/*');
+
+      assert.fileContent('bower.json', 'assets/javascripts/bootstrap.js');
+    });
   });
 
   describe('without Sass', function () {
@@ -84,6 +94,18 @@ describe('Bootstrap feature', function () {
 
     it('should output the correct <script> paths', function () {
       assert.fileContent('app/index.html', /src=\"(.*?)\/bootstrap\/js\//);
+    });
+
+    it('should correctly override bootstrap\'s bower.json', function() {
+      assert.fileContent('bower.json', '"overrides"');
+
+      assert.fileContent('bower.json', 'less/bootstrap.less');
+
+      assert.fileContent('bower.json', 'dist/css/bootstrap.css');
+
+      assert.fileContent('bower.json', 'dist/js/bootstrap.js');
+
+      assert.fileContent('bower.json', 'dist/fonts/*');
     });
   });
 });


### PR DESCRIPTION
This addresses #338 as an alternative to ecf4928 by populating bower.json with either of these, depending on whether sass is selected or not, thus allowing us to keep bootstrap up-to-date.

``` json
"overrides":
  "bootstrap-sass": {
    "main": [
      "assets/stylesheets/_bootstrap.scss",
      "assets/fonts/bootstrap/*",
      "assets/javascripts/bootstrap.js"
    ]
  }
}
```

``` json
"overrides":
  "bootstrap": {
    "main": [
      "less/bootstrap.less",
      "dist/css/bootstrap.css",
      "dist/js/bootstrap.js",
      "dist/fonts/*"
    ]
  }
}
```

I could not figure out a way to test the actual result of the `fonts` task, so the test just checks whether the font paths are present in bower.json.

This should be a temporary measure until [this issue](https://github.com/bower/bower.json-spec/issues/47) is resolved and bootstrap also updates accordingly.
