### PR TITLE
avoid main-bower-files spitting error when there is no bower deps

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -77,9 +77,8 @@ gulp.task('images', () => {
 });
 
 gulp.task('fonts', () => {
-  return gulp.src(require('main-bower-files')({
-    filter: '**/*.{eot,svg,ttf,woff,woff2}'
-  }).concat('app/fonts/**/*'))
+  return gulp.src(require('main-bower-files')('**/*.{eot,svg,ttf,woff,woff2}', function (err) {})
+    .concat('app/fonts/**/*'))
     .pipe(gulp.dest('.tmp/fonts'))
     .pipe(gulp.dest('dist/fonts'));
 });


### PR DESCRIPTION
When there is no bower deps it will error when running `gulp`. You have to create an empty bower_components by hand. This fix avoids it.

Ref: https://github.com/ck86/main-bower-files/issues/103
