### PR TITLE
Added improved revision functionality.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,8 @@
     "gulp-imagemin": "^2.2.1",
     "gulp-load-plugins": "^0.10.0",
     "gulp-minify-css": "^1.1.1",
-    "gulp-minify-html": "^1.0.0",<% if (includeSass) { %>
+    "gulp-minify-html": "^1.0.0",
+    "gulp-rev-all": "^0.8.0",<% if (includeSass) { %>
     "gulp-plumber": "^1.0.1",
     "gulp-sass": "^2.0.0",<% } %>
     "gulp-size": "^1.2.1",

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -7,6 +7,7 @@ import {stream as wiredep} from 'wiredep';
 
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
+const revAll = new $.revAll({dontRenameFile: ['favicon.ico', 'apple-touch-icon.png', 'robots.txt', '.html']});
 
 gulp.task('styles', () => {<% if (includeSass) { %>
   return gulp.src('app/styles/*.scss')
@@ -57,7 +58,7 @@ gulp.task('html', ['styles'], () => {
     .pipe(assets.restore())
     .pipe($.useref())
     .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest('.tmp'));
 });
 
 gulp.task('images', () => {
@@ -73,14 +74,13 @@ gulp.task('images', () => {
       console.log(err);
       this.end();
     })))
-    .pipe(gulp.dest('dist/images'));
+    .pipe(gulp.dest('.tmp/images'));
 });
 
 gulp.task('fonts', () => {
   return gulp.src(require('main-bower-files')('**/*.{eot,svg,ttf,woff,woff2}', function (err) {})
     .concat('app/fonts/**/*'))
     .pipe(gulp.dest('.tmp/fonts'))
-    .pipe(gulp.dest('dist/fonts'));
 });
 
 gulp.task('extras', () => {
@@ -89,7 +89,7 @@ gulp.task('extras', () => {
     '!app/*.html'
   ], {
     dot: true
-  }).pipe(gulp.dest('dist'));
+  }).pipe(gulp.dest('.tmp'));
 });
 
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
@@ -163,7 +163,10 @@ gulp.task('wiredep', () => {<% if (includeSass) { %>
 });
 
 gulp.task('build', ['lint', 'html', 'images', 'fonts', 'extras'], () => {
-  return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
+   return gulp.src('.tmp/**/*')
+    .pipe(revAll.revision())
+    .pipe(gulp.dest('dist'))
+    .pipe($.size({title: 'build', gzip: true}));
 });
 
 gulp.task('default', ['clean'], () => {


### PR DESCRIPTION
**Quick Overview**
1. new `constant` revAll to get all the options possible for revving
2. extended the build task to perform revving
3. all files ready for revving are moved to the .tmp directory
4. rev-all searches in .tmp for files, revvs them and moves them to dist folder

**Elaboration**

**1. new `constant`**
The new version of rev-all (> 0.8) needs an instantiation. Furthermore, many more options have been added for customization. 
I thought of making a new revving task, which could be re-used (e.g for deployment), but per scenario a user probably wants different options, which means a new instantiation, and thus a new task.
A constant is the neatest/most compact option from my perspective.

**2. / 3. New build task & .tmp**
Obviously the build task needed to get extended, as we want to perform all other tasks before revving.
The current setup, contrary to the previous, follows the much discussed method of prepping everything into `.tmp`, and then getting the final files stored into `dist`. (see the other PR and issue for the discussion).
- Each task that would store files into the `dist` folder, now does that solely in `.tmp`.
- After all build-tasks are completed, `rev-all` goes over the files in `.tmp`, revvs them accordingly, and stores them in `dist`.
- two major advantages:  1. Only final-ready-to-deploy files are in the `dist` folder. 2. no need for `rev-napkin` and the like to remove un-revved and pre-revved (thus temporary) files. 

**Side note**
I normally test my changes on my own website, however, that is still using v.0.3 and 
a. I don't know how to elgantly upgrade the generator inside that project
b. it's 2.30am so not in the mood to figure that out right now.

I tested this using the standard yeoman/generator webpages that come along with the generator. I don't expect anything weird to happen when I use this on a larger project (famous last words, lol)

Looking at the amount of changes since the first RP I did, I would propose to close that one. Consensus was that this (all to `.tmp`, then to `dist`) was the best method anyway...
