### PR TITLE
Remove `opn` from dependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,7 +23,6 @@
     "gulp-uglify": "^1.1.0",
     "gulp-useref": "^1.1.1",
     "main-bower-files": "^2.5.0",
-    "opn": "^1.0.1",
     "wiredep": "^2.2.2"
   },
   "eslintConfig": {


### PR DESCRIPTION
`opn` is already shipped with `browser-sync`
