### PR TITLE
Binding eslint on javascript files content change

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -114,6 +114,7 @@ gulp.task('serve', ['styles', 'fonts'], () => {
   ]).on('change', reload);
 
   gulp.watch('app/styles/**/*.<%= includeSass ? 'scss' : 'css' %>', ['styles']);
+  gulp.watch('app/scripts/**/*.js', ['lint']);
   gulp.watch('app/fonts/**/*', ['fonts']);
   gulp.watch('bower.json', ['wiredep', 'fonts']);
 });


### PR DESCRIPTION
When I were reviewing code with eslint, I must using **gulp lint** or **gulp build**  EVERY TIME, if just bindling on the file change event will be better to use.
