### PR TITLE
Upgrade gulp-useref to 3.0.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -21,7 +21,7 @@
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^1.1.0",
-    "gulp-useref": "^1.1.1",
+    "gulp-useref": "^3.0.0",
     "main-bower-files": "^2.5.0",
     "wiredep": "^2.2.2"
   },

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -48,14 +48,10 @@ gulp.task('lint', lint('app/scripts/**/*.js'));
 gulp.task('lint:test', lint('test/spec/**/*.js', testLintOptions));
 
 gulp.task('html', ['styles'], () => {
-  const assets = $.useref.assets({searchPath: ['.tmp', 'app', '.']});
-
   return gulp.src('app/*.html')
-    .pipe(assets)
+    .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.minifyCss({compatibility: '*'})))
-    .pipe(assets.restore())
-    .pipe($.useref())
     .pipe($.if('*.html', $.minifyHtml({conditionals: true, loose: true})))
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
Upgrading the gulp-useref plugin to version 3.0. 3.0 has a much simpler API. It only uses one stream now for html and assets so it simplifies the gulp task quite a bit.
