### PR TITLE
Update license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "generator-gulp-webapp",
   "version": "1.0.3",
   "description": "Scaffold out a front-end web app",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "yeoman/generator-gulp-webapp",
   "author": "The Yeoman Team",
   "main": "app/index.js",


### PR DESCRIPTION
This just gets rid of the npm 3.x warning when linking the package.

I expanded the license field to the BSD 2-Clause license (https://spdx.org/licenses/BSD-2-Clause.html) since that's the one that's linked in the readme file.
