### PR TITLE
Using del > v2.0.0 corrects #124

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "babel-core": "^5.5.6",
     "browser-sync": "^2.2.1",
-    "del": "^1.1.1",
+    "del": "^2.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.0.1",
     "gulp-cache": "^0.2.8",

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -8,7 +8,7 @@ import {stream as wiredep} from 'wiredep';
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
 
-gulp.task('styles', () => {<% if (includeSass) { %>
+gulp.task('styles', ['clean'], () => {<% if (includeSass) { %>
   return gulp.src('app/styles/*.scss')
     .pipe($.plumber())
     .pipe($.sourcemaps.init())
@@ -72,7 +72,7 @@ gulp.task('images', () => {
     .pipe(gulp.dest('dist/images'));
 });
 
-gulp.task('fonts', () => {
+gulp.task('fonts', ['clean'], () => {
   return gulp.src(require('main-bower-files')('**/*.{eot,svg,ttf,woff,woff2}', function (err) {})
     .concat('app/fonts/**/*'))
     .pipe(gulp.dest('.tmp/fonts'))
@@ -92,7 +92,7 @@ gulp.task('clean', () => {
   return del.bind(null, ['.tmp', 'dist']);
 });
 
-gulp.task('serve', ['clean', 'styles', 'fonts'], () => {
+gulp.task('serve', ['styles', 'fonts'], () => {
   browserSync({
     notify: false,
     port: 9000,
@@ -165,6 +165,4 @@ gulp.task('build', ['lint', 'html', 'images', 'fonts', 'extras'], () => {
   return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
 });
 
-gulp.task('default', ['clean'], () => {
-  gulp.start('build');
-});
+gulp.task('default', ['build']);

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -88,9 +88,11 @@ gulp.task('extras', () => {
   }).pipe(gulp.dest('dist'));
 });
 
-gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
+gulp.task('clean', () => {
+  return del.bind(null, ['.tmp', 'dist']);
+});
 
-gulp.task('serve', ['styles', 'fonts'], () => {
+gulp.task('serve', ['clean', 'styles', 'fonts'], () => {
   browserSync({
     notify: false,
     port: 9000,


### PR DESCRIPTION
The gulp tasks have changed quite a bit since #124 was first introduced but that fortunately made correcting this much easier.

I first verified the problem still persists by adding the `clean` dependency to `serve`. It would fail as expected as either the fonts or styles directories wouldn't be empty during async execution. Once I changed to the promise syntax, `clean` would wait for completion before `fonts` and `styles` began.

I tried to recreate as much of the work done in the issue as possible by also creating a fresh project and testing the changes. I believe both the default `gulp` and `gulp serve` work as expected.
