### PR TITLE
use gulp-cli instead of gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If your favorite feature is missing and you really need Ruby Sass, you can alway
 
 ## Getting Started
 
-- Install dependencies: `npm install --global yo gulp bower`
+- Install dependencies: `npm install --global yo gulp-cli bower`
 - Install the generator: `npm install --global generator-gulp-webapp`
 - Run `yo gulp-webapp` to scaffold your webapp
 - Run `gulp serve` to preview and watch for changes


### PR DESCRIPTION
Use `gulp-cli` instead of `gulp` for running gulp tasks.
