### PR TITLE
Add Gulp file include

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,6 +14,7 @@
     "gulp-cache": "^0.4.2",
     "gulp-cssnano": "^2.0.0",
     "gulp-eslint": "^0.13.2",
+    "gulp-file-include": "^0.13.7",
     "gulp-htmlmin": "^1.3.0",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.2.1",

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -37,6 +37,14 @@ gulp.task('scripts', () => {
 });
 <% } -%>
 
+gulp.task('html', function() {
+  return gulp.src('app/*.html')
+    .pipe($.plumber())
+    .pipe($.fileInclude())
+    .pipe(gulp.dest('.tmp/'))
+    .pipe(reload({stream: true}));
+});
+
 function lint(files, options) {
   return () => {
     return gulp.src(files)
@@ -60,11 +68,11 @@ gulp.task('lint', lint('app/scripts/**/*.js'));
 gulp.task('lint:test', lint('test/spec/**/*.js', testLintOptions));
 
 <% if (includeBabel) { -%>
-gulp.task('html', ['styles', 'scripts'], () => {
+gulp.task('useref', ['html', 'styles', 'scripts'], () => {
 <% } else { -%>
-gulp.task('html', ['styles'], () => {
+gulp.task('useref', ['html', 'styles'], () => {
 <% } -%>
-  return gulp.src('app/*.html')
+  return gulp.src('.tmp/*.html')
     .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.if('*.js', $.uglify()))
     .pipe($.if('*.css', $.cssnano()))
@@ -103,9 +111,9 @@ gulp.task('extras', () => {
 gulp.task('clean', del.bind(null, ['.tmp', 'dist']));
 
 <% if (includeBabel) { -%>
-gulp.task('serve', ['styles', 'scripts', 'fonts'], () => {
+gulp.task('serve', ['html', 'styles', 'scripts', 'fonts'], () => {
 <% } else { -%>
-gulp.task('serve', ['styles', 'fonts'], () => {
+gulp.task('serve', ['html', 'styles', 'fonts'], () => {
 <% } -%>
   browserSync({
     notify: false,
@@ -119,7 +127,6 @@ gulp.task('serve', ['styles', 'fonts'], () => {
   });
 
   gulp.watch([
-    'app/*.html',
 <% if (!includeBabel) { -%>
     'app/scripts/**/*.js',
 <% } -%>
@@ -127,6 +134,7 @@ gulp.task('serve', ['styles', 'fonts'], () => {
     '.tmp/fonts/**/*'
   ]).on('change', reload);
 
+  gulp.watch('app/**/*.html', ['html']);
   gulp.watch('app/styles/**/*.<%= includeSass ? 'scss' : 'css' %>', ['styles']);
 <% if (includeBabel) { -%>
   gulp.watch('app/scripts/**/*.js', ['scripts']);
@@ -191,7 +199,7 @@ gulp.task('wiredep', () => {<% if (includeSass) { %>
     .pipe(gulp.dest('app'));
 });
 
-gulp.task('build', ['lint', 'html', 'images', 'fonts', 'extras'], () => {
+gulp.task('build', ['lint', 'useref', 'images', 'fonts', 'extras'], () => {
   return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
 });
 

--- a/test/babel.js
+++ b/test/babel.js
@@ -24,8 +24,8 @@ describe('Babel feature', function () {
 
     it('should add the scripts task', function () {
       assert.fileContent('gulpfile.babel.js', "gulp.task('scripts'");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'scripts']");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'scripts', 'fonts']");
+      assert.fileContent('gulpfile.babel.js', "['html', 'styles', 'scripts']");
+      assert.fileContent('gulpfile.babel.js', "['html', 'styles', 'scripts', 'fonts']");
       assert.fileContent('gulpfile.babel.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
       assert.fileContent('gulpfile.babel.js', "'/scripts': '.tmp/scripts',");
     });
@@ -51,8 +51,8 @@ describe('Babel feature', function () {
 
     it('shouldn\'t add the scripts task', function () {
       assert.noFileContent('gulpfile.babel.js', "gulp.task('scripts'");
-      assert.fileContent('gulpfile.babel.js', "['styles']");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'fonts']");
+      assert.fileContent('gulpfile.babel.js', "['html', 'styles']");
+      assert.fileContent('gulpfile.babel.js', "['html', 'styles', 'fonts']");
       assert.fileContent('gulpfile.babel.js', "'app/scripts/**/*.js',");
       assert.noFileContent('gulpfile.babel.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
       assert.fileContent('gulpfile.babel.js', "'/scripts': 'app/scripts',");


### PR DESCRIPTION
Hey guys,

I thought this would be a useful addition to the generator. It includes the gulp-file-include plugin, which allows people to _optionally_ use code like:

``` html
  @@include('./partials/view.html')
  @@include('./var.html', {
    "name": "haoxin",
    "age": 12345,
    "socials": {
      "fb": "facebook.com/include",
      "tw": "twitter.com/include"
    }
  })
```

This is always useful with small frontend projects where the developer is endlessly copying and pasting snippets of HTML for repeating elements like comments, blog articles, generated content etc... 

If they don't use these snippets, then everything works as it always did :) 

I did rename the html gulp task to useref, and used the html task for gulp file include as I felt it was more relevant, however happy to have these renamed. 
