### PR TITLE
Update to yo-gen 0.22 and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 node_modules
-test/gulp-file
-test/sass
-test/slug
-temp/

--- a/package.json
+++ b/package.json
@@ -29,15 +29,16 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "generator-jasmine": "^0.2.1",
-    "generator-mocha": "^0.2.0",
+    "generator-mocha": "^0.3.0",
     "mkdirp": "^0.5.1",
     "underscore.string": "^3.1.1",
     "wiredep": "^2.2.2",
-    "yeoman-assert": "^2.0.0",
-    "yeoman-generator": "^0.20.1",
+    "yeoman-assert": "^2.1.1",
+    "yeoman-generator": "^0.22.5",
     "yosay": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "yeoman-test": "^1.1.0"
   }
 }

--- a/test/babel.js
+++ b/test/babel.js
@@ -1,14 +1,13 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('Babel feature', function () {
   describe('on', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true, babel: true})
+        .withOptions({babel: true})
         .withPrompts({features: []})
         .on('end', done);
     });
@@ -34,8 +33,7 @@ describe('Babel feature', function () {
   describe('off', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true, babel: false})
+        .withOptions({babel: false})
         .withPrompts({features: []})
         .on('end', done);
     });

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,14 +1,12 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('Bootstrap feature', function () {
   describe('on', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({features: [
           'includeBootstrap'
         ]})
@@ -27,8 +25,6 @@ describe('Bootstrap feature', function () {
   describe('off', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({features: []})
         .on('end', done);
     });
@@ -45,8 +41,6 @@ describe('Bootstrap feature', function () {
   describe('with Sass', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({features: [
           'includeSass',
           'includeBootstrap'
@@ -80,8 +74,6 @@ describe('Bootstrap feature', function () {
   describe('without Sass', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({features: [
           'includeBootstrap'
         ]})

--- a/test/general.js
+++ b/test/general.js
@@ -1,15 +1,11 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('general', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(__dirname, 'temp'))
-      .withOptions({
-        'skip-install': true
-      })
       .withPrompts({features: []})
       .withGenerators([
         [helpers.createDummyGenerator(), 'mocha:app']

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -1,14 +1,12 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('jQuery feature', function () {
   describe('on', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({
           features: [],
           includeJQuery: true
@@ -24,8 +22,6 @@ describe('jQuery feature', function () {
   describe('off', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({
           features: [],
           includeJQuery: false

--- a/test/sass.js
+++ b/test/sass.js
@@ -1,14 +1,12 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('Sass feature', function () {
   describe('on', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true})
         .withPrompts({features: [
           'includeSass'
         ]})
@@ -28,8 +26,7 @@ describe('Sass feature', function () {
   describe('off', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({'skip-install': true, 'babel': false})
+        .withOptions({'babel': false})
         .withPrompts({features: []})
         .on('end', done);
     });

--- a/test/slug.js
+++ b/test/slug.js
@@ -1,21 +1,19 @@
 'use strict';
 var path = require('path');
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
-var helpers = require('yeoman-generator').test;
 
 describe('slug name', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(__dirname, 'temp'))
-      .withOptions({'skip-install': true})
       .withPrompts({features: []})
-      .on('end', done)
+      .on('end', done);
   });
 
   it('should generate the same appname in every file', function () {
-    var expectedAppName = 'temp';
+    var name = path.basename(process.cwd());
 
-    assert.fileContent('bower.json', '"name": "temp"');
-    assert.fileContent('app/index.html', '<title>temp</title>');
+    assert.fileContent('bower.json', '"name": "' + name + '"');
+    assert.fileContent('app/index.html', '<title>' + name + '</title>');
   });
 });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -1,13 +1,11 @@
 'use strict';
 var path = require('path');
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
-var helpers = require('yeoman-generator').test;
 
 describe('gulp tasks', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(__dirname, 'temp'))
-      .withOptions({'skip-install': true})
       .withPrompts({features: []})
       .on('end', done);
   });

--- a/test/test-framework.js
+++ b/test/test-framework.js
@@ -1,17 +1,13 @@
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('test framework', function () {
   describe('mocha', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({
-          'skip-install': true,
-          'test-framework': 'mocha'
-        })
+        .withOptions({'test-framework': 'mocha'})
         .withPrompts({features: []})
         .on('end', done);
     });
@@ -28,11 +24,7 @@ describe('test framework', function () {
   describe('jasmine', function () {
     before(function (done) {
       helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, 'temp'))
-        .withOptions({
-          'skip-install': true,
-          'test-framework': 'jasmine'
-        })
+        .withOptions({'test-framework': 'jasmine'})
         .withPrompts({features: []})
         .on('end', done);
     });


### PR DESCRIPTION
- Removes entries from gitignore for old style tests
- Update to use yeoman-test
- Update tests to run in os tmp dir instead of test/temp
