### PR TITLE
Update jade docs follow version 2.0.0

### DIFF
--- a/docs/recipes/jade.md
+++ b/docs/recipes/jade.md
@@ -36,6 +36,7 @@ Add this task to your `gulpfile.babel.js`, it will compile `.jade` files to `.ht
 ```js
 gulp.task('views', () => {
   return gulp.src('app/*.jade')
+    .pipe($.plumber())
     .pipe($.jade({pretty: true}))
     .pipe(gulp.dest('.tmp'))
     .pipe(reload({stream: true}));


### PR DESCRIPTION
Update content in gulpfile.babel.js follow ver 2.0.0 and add gulp-plumber to prevent views task break.
