### PR TITLE
Remove .sass-cache folder from gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
 .tmp
-.sass-cache
 bower_components
 test/bower_components


### PR DESCRIPTION
Using LibSass instead of Ruby Sass removed the `.sass-cache` folder.
