### PR TITLE
Don't parse gulpfile with babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 ## Features
 
-Please see our [gulpfile](app/templates/gulpfile.babel.js) for up to date information on what we support.
+Please see our [gulpfile](app/templates/gulpfile.js) for up to date information on what we support.
 
+* enable [ES2015 features](https://babeljs.io/docs/learn-es2015/) using [Babel](https://babeljs.io)
 * CSS Autoprefixing
 * Built-in preview server with BrowserSync
 * Automagically compile Sass with [libsass](http://libsass.org)
@@ -16,7 +17,6 @@ Please see our [gulpfile](app/templates/gulpfile.babel.js) for up to date inform
 * Map compiled CSS to source stylesheets with source maps
 * Awesome image optimization
 * Automagically wire-up dependencies installed with [Bower](http://bower.io)
-* The gulpfile makes use of [ES2015 features](https://babeljs.io/docs/learn-es2015/) by using [Babel](https://babeljs.io)
 
 *For more information on what this generator can do for you, take a look at the [gulp plugins](app/templates/_package.json) used in our `package.json`.*
 
@@ -59,7 +59,7 @@ If your favorite feature is missing and you really need Ruby Sass, you can alway
 - `--test-framework=<framework>`
   Either `mocha` or `jasmine`. Defaults to `mocha`.
 - `--no-babel`
-  Scaffolds without [Babel](http://babeljs.io) support (this only applies to `app/scripts`, you can still write ES2015 in the gulpfile)
+  Scaffolds without [Babel](http://babeljs.io) support. This only applies to `app/scripts`, you can still write ES2015 in the gulpfile, depending on what your version of Node [supports](https://kangax.github.io/compat-table/es6/).
 
 
 ## Contribute

--- a/app/USAGE
+++ b/app/USAGE
@@ -11,7 +11,7 @@ Example:
     yo webapp
 
     This will create:
-        gulpfile.babel.js: Configuration for the task runner.
+        gulpfile.js: Configuration for the task runner.
         bower.json: Front-end packages installed by bower.
         package.json: Development packages installed by npm.
 

--- a/app/index.js
+++ b/app/index.js
@@ -108,8 +108,8 @@ module.exports = generators.Base.extend({
   writing: {
     gulpfile: function () {
       this.fs.copyTpl(
-        this.templatePath('gulpfile.babel.js'),
-        this.destinationPath('gulpfile.babel.js'),
+        this.templatePath('gulpfile.js'),
+        this.destinationPath('gulpfile.js'),
         {
           date: (new Date).toISOString().split('T')[0],
           name: this.pkg.name,

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4"
   },
   "devDependencies": {
     "babel-core": "^6.4.0",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -1,9 +1,9 @@
 // generated on <%= date %> using <%= name %> <%= version %>
-import gulp from 'gulp';
-import gulpLoadPlugins from 'gulp-load-plugins';
-import browserSync from 'browser-sync';
-import del from 'del';
-import {stream as wiredep} from 'wiredep';
+const gulp = require('gulp');
+const gulpLoadPlugins = require('gulp-load-plugins');
+const browserSync = require('browser-sync');
+const del = require('del');
+const wiredep = require('wiredep').stream;
 
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;

--- a/docs/recipes/browserify.md
+++ b/docs/recipes/browserify.md
@@ -14,13 +14,13 @@ $ npm install -save babelify vinyl-buffer vinyl-source-stream
 ### 2. Edit your `scripts` task
 
 ```diff
- import browserSync from 'browser-sync';
- import del from 'del';
- import {stream as wiredep} from 'wiredep';
-+import browserify from 'browserify';
-+import babelify from 'babelify';
-+import buffer from 'vinyl-buffer';
-+import source from 'vinyl-source-stream';
+ const browserSync = require('browser-sync');
+ const del = require('del');
+ const wiredep = require('wiredep').stream;
++const browserify = require('browserify');
++const babelify = require('babelify');
++const buffer = require('vinyl-buffer');
++const source = require('vinyl-source-stream');
 ```
 
 ```diff
@@ -46,7 +46,7 @@ gulp.task('scripts', () => {
 });
 ```
 
-### 3. Edit your `index.html` 
+### 3. Edit your `index.html`
 
 We are going to require the compiled bundle.
 
@@ -77,4 +77,3 @@ And then in your `main.js`:
 const foo = require('./foo');
 foo.speak();
 ```
-

--- a/docs/recipes/jade.md
+++ b/docs/recipes/jade.md
@@ -31,7 +31,7 @@ $ npm install --save-dev gulp-jade
 
 ### 2. Create a `views` task
 
-Add this task to your `gulpfile.babel.js`, it will compile `.jade` files to `.html` files in `.tmp`:
+Add this task to your `gulpfile.js`, it will compile `.jade` files to `.html` files in `.tmp`:
 
 ```js
 gulp.task('views', () => {

--- a/docs/recipes/react-router.md
+++ b/docs/recipes/react-router.md
@@ -31,7 +31,7 @@ window.Router = require('react-router');
 At the top of the gulpfile, add:
 
 ```js
-import webpack from 'webpack';
+const webpack = require('webpack');
 ```
 
 Add the task. This task bundles the webpack script, including React Router, and outputs it in `.tmp/scripts`.

--- a/docs/recipes/rsync-deploy.md
+++ b/docs/recipes/rsync-deploy.md
@@ -37,7 +37,7 @@ for example
 
 ### 3. Create a `deploy` task
 
-Add this task to your `gulpfile.babel.js`. It will run `build` task before deploying:
+Add this task to your `gulpfile.js`. It will run `build` task before deploying:
 
 ```js
 gulp.task('deploy', ['build'], () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "The Yeoman Team",
   "main": "app/index.js",
   "engines": {
-    "node": ">=0.10.0",
+    "node": ">=4",
     "npm": ">=1.3"
   },
   "scripts": {

--- a/test/babel.js
+++ b/test/babel.js
@@ -22,11 +22,11 @@ describe('Babel feature', function () {
     });
 
     it('should add the scripts task', function () {
-      assert.fileContent('gulpfile.babel.js', "gulp.task('scripts'");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'scripts']");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'scripts', 'fonts']");
-      assert.fileContent('gulpfile.babel.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
-      assert.fileContent('gulpfile.babel.js', "'/scripts': '.tmp/scripts',");
+      assert.fileContent('gulpfile.js', "gulp.task('scripts'");
+      assert.fileContent('gulpfile.js', "['styles', 'scripts']");
+      assert.fileContent('gulpfile.js', "['styles', 'scripts', 'fonts']");
+      assert.fileContent('gulpfile.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
+      assert.fileContent('gulpfile.js', "'/scripts': '.tmp/scripts',");
     });
   });
 
@@ -48,12 +48,12 @@ describe('Babel feature', function () {
     });
 
     it('shouldn\'t add the scripts task', function () {
-      assert.noFileContent('gulpfile.babel.js', "gulp.task('scripts'");
-      assert.fileContent('gulpfile.babel.js', "['styles']");
-      assert.fileContent('gulpfile.babel.js', "['styles', 'fonts']");
-      assert.fileContent('gulpfile.babel.js', "'app/scripts/**/*.js',");
-      assert.noFileContent('gulpfile.babel.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
-      assert.fileContent('gulpfile.babel.js', "'/scripts': 'app/scripts',");
+      assert.noFileContent('gulpfile.js', "gulp.task('scripts'");
+      assert.fileContent('gulpfile.js', "['styles']");
+      assert.fileContent('gulpfile.js', "['styles', 'fonts']");
+      assert.fileContent('gulpfile.js', "'app/scripts/**/*.js',");
+      assert.noFileContent('gulpfile.js', "gulp.watch('app/scripts/**/*.js', ['scripts'])");
+      assert.fileContent('gulpfile.js', "'/scripts': 'app/scripts',");
     });
   });
 });

--- a/test/general.js
+++ b/test/general.js
@@ -22,7 +22,7 @@ describe('general', function () {
     assert.file([
       'bower.json',
       'package.json',
-      'gulpfile.babel.js',
+      'gulpfile.js',
       '.babelrc',
       '.editorconfig',
       '.bowerrc',

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -27,7 +27,7 @@ describe('gulp tasks', function () {
       'build',
       'default'
     ].forEach(function (task) {
-      assert.fileContent('gulpfile.babel.js', 'gulp.task(\'' + task);
+      assert.fileContent('gulpfile.js', 'gulp.task(\'' + task);
     });
   });
 });

--- a/test/test-framework.js
+++ b/test/test-framework.js
@@ -13,7 +13,7 @@ describe('test framework', function () {
     });
 
     it('uses the correct ESLint environment', function () {
-      assert.fileContent('gulpfile.babel.js', 'mocha: true');
+      assert.fileContent('gulpfile.js', 'mocha: true');
     });
 
     it('generates the expected fixture', function () {
@@ -30,7 +30,7 @@ describe('test framework', function () {
     });
 
     it('uses the correct ESLint environment', function () {
-      assert.fileContent('gulpfile.babel.js', 'jasmine: true');
+      assert.fileContent('gulpfile.js', 'jasmine: true');
     });
 
     it('generates the expected fixture', function () {


### PR DESCRIPTION
It used to make sense, but now ES2015 support is supported well enough in Node v4 and higher (those are the ones we support anyway), so this will reduce the initial loading time when running gulp tasks.

Fixes #407.
