### PR TITLE
Bump `gulp-imagemin`

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,7 +17,7 @@
     "gulp-eslint": "^2.0.0",
     "gulp-htmlmin": "^1.3.0",
     "gulp-if": "^2.0.0",
-    "gulp-imagemin": "^2.2.1",
+    "gulp-imagemin": "^3.0.1",
     "gulp-load-plugins": "^0.10.0",<% if (includeBabel || includeSass) { %>
     "gulp-plumber": "^1.0.1",<% } if (includeSass) { %>
     "gulp-sass": "^2.0.0",<% } %>

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -80,13 +80,7 @@ gulp.task('html', ['styles'], () => {
 
 gulp.task('images', () => {
   return gulp.src('app/images/**/*')
-    .pipe($.cache($.imagemin({
-      progressive: true,
-      interlaced: true,
-      // don't remove IDs from SVGs, they are often used
-      // as hooks for embedding and styling
-      svgoPlugins: [{cleanupIDs: false}]
-    })))
+    .pipe($.cache($.imagemin()))
     .pipe(gulp.dest('dist/images'));
 });
 


### PR DESCRIPTION
If we want to keep the options we can do:

``` js
$.imagemin([
    $.imagemin.gifsicle({interlaced: true}),
    $.imagemin.jpegtran({progressive: true}),
    $.imagemin.optipng(),
    $.imagemin.svgo({plugins: [{cleanupIDs: false}]})
]);
```
