### PR TITLE
Fix linting tests

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -62,7 +62,7 @@ gulp.task('lint:test', () => {
 <% } -%>
     }
   })
-    .pipe(gulp.dest('test/spec/**/*.js'));
+    .pipe(gulp.dest('test/spec'));
 });
 
 <% if (includeBabel) { -%>


### PR DESCRIPTION
change `gulp.dest` in `gulp.task('lint:test')` to prevent errors.
