### PR TITLE
Copy fonts to .tmp/ or dist/ depending on task.

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -8,6 +8,11 @@ const wiredep = require('wiredep').stream;
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
 
+var dev = true;
+gulp.task('set-prod-mode', function () {
+  dev = false;
+});
+
 gulp.task('styles', () => {<% if (includeSass) { %>
   return gulp.src('app/styles/*.scss')
     .pipe($.plumber())
@@ -87,8 +92,7 @@ gulp.task('images', () => {
 gulp.task('fonts', () => {
   return gulp.src(require('main-bower-files')('**/*.{eot,svg,ttf,woff,woff2}', function (err) {})
     .concat('app/fonts/**/*'))
-    .pipe(gulp.dest('.tmp/fonts'))
-    .pipe(gulp.dest('dist/fonts'));
+    .pipe($.if(dev, gulp.dest('.tmp/fonts'), gulp.dest('dist/fonts')));
 });
 
 gulp.task('extras', () => {
@@ -191,7 +195,7 @@ gulp.task('wiredep', () => {<% if (includeSass) { %>
     .pipe(gulp.dest('app'));
 });
 
-gulp.task('build', ['lint', 'html', 'images', 'fonts', 'extras'], () => {
+gulp.task('build', ['set-prod-mode', 'lint', 'html', 'images', 'fonts', 'extras'], () => {
   return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
 });
 

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -9,9 +9,6 @@ const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
 
 var dev = true;
-gulp.task('set-prod-mode', function () {
-  dev = false;
-});
 
 gulp.task('styles', () => {<% if (includeSass) { %>
   return gulp.src('app/styles/*.scss')
@@ -195,10 +192,11 @@ gulp.task('wiredep', () => {<% if (includeSass) { %>
     .pipe(gulp.dest('app'));
 });
 
-gulp.task('build', ['set-prod-mode', 'lint', 'html', 'images', 'fonts', 'extras'], () => {
+gulp.task('build', ['lint', 'html', 'images', 'fonts', 'extras'], () => {
   return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
 });
 
 gulp.task('default', ['clean'], () => {
+  dev = false;
   gulp.start('build');
 });


### PR DESCRIPTION
Right now changing fonts while running serve or build task will copy fonts to both "dist/fonts" and ".tmp/fonts", which doesn't seem logical to me. Development tasks shouldn't modify the dist, and vice-versa.

Used gulp-if to choose either ".tmp\fonts" (for serve task) or "dist\fonts" (for build task) as a destination for fonts.
I've added a variable "dev= false" which is set to false (via 'set-prod-mode' task) to true on "build".
Not sure if it's a good practice, can someone confirm?

I'm also considering another change to 'fonts' task, using [gulp-newer](https://www.npmjs.com/package/gulp-newer), to skip re-writing unmodified fonts, saving the HDD from useless work.
This can be also done for images.
Should I do it?
