### PR TITLE
Reload serve:test on test/index.html changes.

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -170,7 +170,7 @@ gulp.task('serve:test', () => {
 <% if (includeBabel) { -%>
   gulp.watch('app/scripts/**/*.js', ['scripts']);
 <% } -%>
-  gulp.watch('test/spec/**/*.js').on('change', reload);
+  gulp.watch(['test/spec/**/*.js', 'test/index.html']).on('change', reload);
   gulp.watch('test/spec/**/*.js', ['lint:test']);
 });
 


### PR DESCRIPTION
Sometimes one needs to include js files on index.html
Manually restarting serve:test means browersync will
open another tab on chrome and one needs to manually
reload all browsers.

Unless you do a quick fake change in a spec file to force reload.

As this is at most a very small improvement, feel free to discard
it as not wanted. ;D
