### PR TITLE
Removed `options` param from lint function

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('scripts', () => {
 });
 <% } -%>
 
-function lint(files, options) {
+function lint(files) {
   return gulp.src(files)
     .pipe($.eslint({ fix: true }))
     .pipe(reload({stream: true, once: true}))


### PR DESCRIPTION
After this code [commit](https://github.com/yeoman/generator-webapp/commit/796efb90a442f390fa689a776c5f7bab527af537) we no longer need the `options` param when calling the `lint` function.