### PR TITLE
Remove yo as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "jquery",
     "gulp"
   ],
-  "peerDependencies": {
-    "yo": ">=1.7.1"
-  },
   "dependencies": {
     "chalk": "^1.0.0",
     "generator-jasmine": "^0.2.1",


### PR DESCRIPTION
Reason: avoid confusion.

Beside #603 there are questions from time to time in the Yeoman Gitter channel. 