### PR TITLE
s3-deploy recipe back to working order

### DIFF
--- a/docs/recipes/aws-s3-deployment.md
+++ b/docs/recipes/aws-s3-deployment.md
@@ -18,12 +18,12 @@ $ npm install --save-dev gulp-awspublish
 Add this task to your `gulpfile.js`. It will run `build` task before deploying:
 
 ```js
-gulp.task('deploy', ['build'], () => {
+gulp.task('deploy', ['default'], () => {
   // create a new publisher
   const publisher = $.awspublish.create({
-    key: '...',
-    secret: '...',
-    bucket: '...'
+    params: {
+      'Bucket': '...'
+    }
   });
 
   // define custom headers


### PR DESCRIPTION
The recipe was using 'build' instead of 'default' which resulted in no fonts being uploaded.

Also, the gulp plugin now uses 'params' instead of 'bucket' directly.