### PR TITLE
fix RegEx issue within html task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -64,9 +64,9 @@ gulp.task('html', ['styles'], () => {
 <% } -%>
   return gulp.src('app/*.html')
     .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
-    .pipe($.if('/\.js$/', $.uglify({compress: {drop_console: true}})))
-    .pipe($.if('/\.css$/b', $.cssnano({safe: true, autoprefixer: false})))
-    .pipe($.if('/\.html$/', $.htmlmin({
+    .pipe($.if(/\.js$/, $.uglify({compress: {drop_console: true}})))
+    .pipe($.if(/\.css$/, $.cssnano({safe: true, autoprefixer: false})))
+    .pipe($.if(/\.html$/, $.htmlmin({
       collapseWhitespace: true,
       minifyCSS: true,
       minifyJS: {compress: {drop_console: true}},


### PR DESCRIPTION
The generator in its current state is not successfully uglifying JS or minifying CSS/HTML after running `gulp` and then `gulp serve:dist`. I believe this is because the Regular Expressions in the Gulp html task are mistakenly included as strings. 

Additionally, I see no use for the "$" character ... or the "b" character in the cssnano task. Perhaps there is a use for these, but the solution I've provided seems to work.

**Edit**: I intended to also exclude the "$" in this commit, but did not. Sorry about that!