### PR TITLE
Updated to bootstrap~4.0.0-beta

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -170,7 +170,8 @@ module.exports = class extends Generator {
 
       // Bootstrap 4
       bowerJson.dependencies = {
-        'bootstrap': '~4.0.0-alpha.6'
+        'bootstrap': '~4.0.0-beta',
+        'popper.js-unpkg': 'https://unpkg.com/popper.js'
       };
 
       // Bootstrap 3
@@ -263,9 +264,13 @@ module.exports = class extends Generator {
   }
 
   _writingScripts() {
-    this.fs.copy(
+    this.fs.copyTpl(
       this.templatePath('main.js'),
-      this.destinationPath('app/scripts/main.js')
+      this.destinationPath('app/scripts/main.js'),
+      {
+        includeBootstrap: this.includeBootstrap,
+        legacyBootstrap: this.legacyBootstrap
+      }
     );
   }
 
@@ -377,4 +382,4 @@ front end dependencies by running ${chalk.yellow.bold('gulp wiredep')}.`;
       });
     }
   }
-}
+};

--- a/app/templates/main.js
+++ b/app/templates/main.js
@@ -1,1 +1,10 @@
 console.log('\'Allo \'Allo!');
+<% if (includeBootstrap && !legacyBootstrap) { %>
+// Uncomment to enable Bootstrap tooltips
+// https://getbootstrap.com/docs/4.0/components/tooltips/#example-enable-tooltips-everywhere
+// $(function () { $('[data-toggle="tooltip"]').tooltip(); });
+
+// Uncomment to enable Bootstrap popovers
+// https://getbootstrap.com/docs/4.0/components/popovers/#example-enable-popovers-everywhere
+// $(function () { $('[data-toggle="popover"]').popover(); });
+<% } -%>

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -17,7 +17,7 @@ describe('Bootstrap feature', () => {
     });
 
     it('should add the comment block', () => {
-      assert.fileContent('app/index.html', 'build:js scripts/plugins.js')
+      assert.fileContent('app/index.html', 'build:js scripts/plugins.js');
     });
   });
 
@@ -33,7 +33,7 @@ describe('Bootstrap feature', () => {
     });
 
     it('shouldn\'t add the comment block', () => {
-      assert.noFileContent('app/index.html', 'build:js scripts/plugins.js')
+      assert.noFileContent('app/index.html', 'build:js scripts/plugins.js');
     });
   });
 


### PR DESCRIPTION
... which requires popper.js: https://github.com/FezVrasta/popper.js#installation 

Unfortunately it seems impossible to override bootstraps' dependencies in bower.json 😣