### PR TITLE
Fix jQuery and Popper.js call in Bootstrap4

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -170,15 +170,47 @@ module.exports = class extends Generator {
 
       // Bootstrap 4
       bowerJson.dependencies = {
-        'bootstrap': '~4.0.0-beta',
-        'popper.js-unpkg': 'https://unpkg.com/popper.js'
+        "bootstrap": "~4.0.0",
+        "jquery": "~3.3.1",
+        "popper.js": "~1.14.3"
       };
+
+      if (this.includeSass) {
+        bowerJson.overrides = {
+          'bootstrap': {
+            'main': [
+              'scss/bootstrap.scss',
+              'dist/js/bootstrap.js'
+            ]
+          },
+          'popper.js': {
+            'main': [
+              'dist/umd/popper.js'
+            ]
+          }
+        };
+      } else {
+        bowerJson.overrides = {
+          'bootstrap': {
+            'main': [
+              'dist/css/bootstrap.css',
+              'dist/js/bootstrap.js'
+            ]
+          },
+          'popper.js': {
+            'main': [
+              'dist/umd/popper.js'
+            ]
+          }
+        };
+      }
 
       // Bootstrap 3
       if (this.legacyBootstrap) {
         if (this.includeSass) {
           bowerJson.dependencies = {
-            'bootstrap-sass': '~3.3.5'
+            'bootstrap-sass': '~3.3.5',
+            'jquery': '~2.1.4'
           };
           bowerJson.overrides = {
             'bootstrap-sass': {
@@ -191,7 +223,8 @@ module.exports = class extends Generator {
           };
         } else {
           bowerJson.dependencies = {
-            'bootstrap': '~3.3.5'
+            'bootstrap': '~3.3.5',
+            'jquery': '~2.1.4'
           };
           bowerJson.overrides = {
             'bootstrap': {
@@ -205,9 +238,10 @@ module.exports = class extends Generator {
           };
         }
       }
+    }
 
-    } else if (this.includeJQuery) {
-      bowerJson.dependencies['jquery'] = '~2.1.1';
+    if (this.includeJQuery) {
+      bowerJson.dependencies['jquery'] = '~3.3.1';
     }
 
     if (this.includeModernizr) {

--- a/app/index.js
+++ b/app/index.js
@@ -170,9 +170,9 @@ module.exports = class extends Generator {
 
       // Bootstrap 4
       bowerJson.dependencies = {
-        "bootstrap": "~4.0.0",
-        "jquery": "~3.3.1",
-        "popper.js": "~1.14.3"
+        'bootstrap': '~4.0.0',
+        'jquery': '~3.3.1',
+        'popper.js': '~1.14.3'
       };
 
       if (this.includeSass) {
@@ -238,9 +238,7 @@ module.exports = class extends Generator {
           };
         }
       }
-    }
-
-    if (this.includeJQuery) {
+    } else if (this.includeJQuery) {
       bowerJson.dependencies['jquery'] = '~3.3.1';
     }
 

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -12,8 +12,8 @@ describe('Bootstrap feature', () => {
         .on('end', done);
     });
 
-    it('shouldn\'t add jQuery explicitly as a dependency', () => {
-      assert.noFileContent('bower.json', '"jquery"');
+    it('should add jQuery explicitly as a dependency', () => {
+      assert.fileContent('bower.json', '"jquery"');
     });
 
     it('should add the comment block', () => {
@@ -26,10 +26,6 @@ describe('Bootstrap feature', () => {
       helpers.run(path.join(__dirname, '../app'))
         .withPrompts({features: []})
         .on('end', done);
-    });
-
-    it('should add jQuery explicitly as a dependency', () => {
-      assert.fileContent('bower.json', '"jquery"');
     });
 
     it('shouldn\'t add the comment block', () => {


### PR DESCRIPTION
When I started a new project I noticed this problem and it was also reported here https://github.com/yeoman/generator-webapp/issues/718 and https://github.com/yeoman/generator-webapp/issues/717

By initializing the generator by choosing the bootstrap4 option it was not loading the plugins (jQuery and Popper.js) in addition to the bootstrap4 styles .. This PR corrects this behavior and is working perfectly.

- Add styles bootstrap v4 (.scss and .css)
- Add popper.js (bootstrap v4 dependency)
- Updating jQuery versions