### PR TITLE
typo in build script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If your favorite feature is missing and you really need Ruby Sass, you can alway
 - Run `npm install --save <package>` to install dependencies, frontend included
 - Run `npm run  serve:test` to run the tests in the browser
 - Run `npm run  serve:test -- --port=8085` to run the tests in the browser in port `8085`
-- Run `npm build` to build your webapp for production
+- Run `npm run build` to build your webapp for production
 - Run `npm run serve:dist` to preview the production build
 - Run `npm run serve:dist -- --port=5000` to preview the production build in port `5000`
 


### PR DESCRIPTION
Should be ```npm run build``` instead of ```npm build```