### PR TITLE
Dependencies updated for generated project

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,48 +5,48 @@
   },
   "dependencies": {
     <%_ if (includeBootstrap) { -%>
-    "bootstrap": "^4.1.3",
+    "bootstrap": "^4.3.1",
     <%_ } if (includeBootstrap || includeJQuery) { -%>
-    "jquery": "^3.3.1"<% if (includeBootstrap || includeModernizr) { %>,<% } %>
+    "jquery": "^3.4.1"<% if (includeBootstrap || includeModernizr) { %>,<% } %>
     <%_ } if (includeModernizr) { -%>
-    "modernizr": "^3.6.0"<% if (includeBootstrap) { %>,<% } %>
+    "modernizr": "^3.7.1"<% if (includeBootstrap) { %>,<% } %>
     <%_ } if (includeBootstrap) { -%>
-    "popper.js": "^1.14.6"
+    "popper.js": "^1.15.0"
     <%_ } -%>
   },
   "devDependencies": {
-    "@babel/core": "^7.1.2",
-    "@babel/preset-env": "^7.1.0",
-    "autoprefixer": "^9.4.4",
-    "browser-sync": "^2.2.1",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "autoprefixer": "^9.5.1",
+    "browser-sync": "^2.26.5",
     "cross-env": "^5.2.0",
-    "cssnano": "^4.1.7",
-    "del": "^3.0.0",
-    "gulp": "^4.0.0",
+    "cssnano": "^4.1.10",
+    "del": "^4.1.1",
+    "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
-    "gulp-cli": "^2.0.1",
+    "gulp-cli": "^2.2.0",
     "gulp-eslint": "^5.0.0",
     <%_ if (includeSass) { -%>
-    "gulp-filter": "^5.1.0",
+    "gulp-filter": "^6.0.0",
     <%_ } -%>
     "gulp-htmlmin": "^5.0.1",
     "gulp-if": "^2.0.2",
-    "gulp-imagemin": "^5.0.3",
-    "gulp-load-plugins": "^1.2.4",
-    "gulp-plumber": "^1.0.1",
+    "gulp-imagemin": "^6.0.0",
+    "gulp-load-plugins": "^1.6.0",
+    "gulp-plumber": "^1.2.1",
     "gulp-postcss": "^8.0.0",
     <%_ if (includeSass) { -%>
     "gulp-sass": "^4.0.2",
     <%_ } -%>
     "gulp-size": "^3.0.0",
-    "gulp-sourcemaps": "^2.2.0",
-    "gulp-uglify": "^3.0.1",
-    "gulp-useref": "^3.0.0",
+    "gulp-sourcemaps": "^2.6.5",
+    "gulp-uglify": "^3.0.2",
+    "gulp-useref": "^3.1.6",
     <%_ if (includeModernizr) { -%>
     "mkdirp": "^0.5.1",
     <%_ } -%>
-    "mocha": "^5.2.0",
-    "yargs": "12.0.5"
+    "mocha": "^6.1.4",
+    "yargs": "13.2.4"
   },
   "scripts": {
     "serve:test": "cross-env NODE_ENV=test gulp serve",


### PR DESCRIPTION
Generated project dependencies upgraded as requested in #759
``` 
 bootstrap           ^4.1.3  →   ^4.3.1 
 jquery              ^3.3.1  →   ^3.4.1 
 modernizr           ^3.6.0  →   ^3.7.1 
 popper.js          ^1.14.6  →  ^1.15.0 
 @babel/core         ^7.1.2  →   ^7.4.5 
 @babel/preset-env   ^7.1.0  →   ^7.4.5 
 autoprefixer        ^9.4.4  →   ^9.5.1 
 browser-sync        ^2.2.1  →  ^2.26.5 
 cssnano             ^4.1.7  →  ^4.1.10 
 del                 ^3.0.0  →   ^4.1.1 
 gulp                ^4.0.0  →   ^4.0.2 
 gulp-cli            ^2.0.1  →   ^2.2.0 
 gulp-filter         ^5.1.0  →   ^6.0.0 
 gulp-imagemin       ^5.0.3  →   ^6.0.0 
 gulp-load-plugins   ^1.2.4  →   ^1.6.0 
 gulp-plumber        ^1.0.1  →   ^1.2.1 
 gulp-sourcemaps     ^2.2.0  →   ^2.6.5 
 gulp-uglify         ^3.0.1  →   ^3.0.2 
 gulp-useref         ^3.0.0  →   ^3.1.6 
 mocha               ^5.2.0  →   ^6.1.4 
 yargs               12.0.5  →   13.2.4 
```